### PR TITLE
Toolbar: Make it easier to tell if a button is disabled

### DIFF
--- a/src/toolbar/toolbar.css
+++ b/src/toolbar/toolbar.css
@@ -34,7 +34,8 @@
 }
 
 .toolbar-button.disabled {
-	filter: opacity(0.8) saturate(0.1);
+	filter: opacity(0.5) sepia(0.2);
+	cursor: unset;
 }
 
 .toolbar-button, .toolbar-root button {
@@ -75,7 +76,7 @@
 	width: 6em;
 }
 
-.toolbar-button:hover, .toolbar-root button:not(:disabled):hover {
+.toolbar-button:not(.disabled):hover, .toolbar-root button:not(:disabled):hover {
 	box-shadow: 0px 2px 4px var(--primary-shadow-color);
 }
 


### PR DESCRIPTION
# Summary
Increases the contrast difference between disabled and enabled toolbar buttons.

# Screenshots/other information
Enabled:
![Buttons in selection tool have full contrast](https://user-images.githubusercontent.com/46334387/192411985-ebb933dc-d166-40ec-a39e-d39afa0cb264.png)

Disabled (with PR):
![Buttons in selection tool have half contrast](https://user-images.githubusercontent.com/46334387/192411934-30d3ac13-3e7e-42d8-bcf8-dd3cf8300c53.png)

