### PR TITLE
Make pen icons look more like pens/pencils

### DIFF
--- a/src/Color4.test.ts
+++ b/src/Color4.test.ts
@@ -16,4 +16,15 @@ describe('Color4', () => {
 		expect(Color4.fromString('rgba ( 255, 0,\t 0, 0.5)')).objEq(Color4.ofRGBA(1, 0, 0, 0.5));
 		expect(Color4.fromString('rgba( 0, 0, 128, 0)')).objEq(Color4.ofRGBA(0, 0, 128/255, 0));
 	});
+
+	it('should mix blue and red to get dark purple', () => {
+		expect(Color4.ofRGB(1, 0, 0).mix(Color4.ofRGB(0, 0, 1), 0.5)).objEq(Color4.ofRGB(0.5, 0, 0.5));
+		expect(Color4.ofRGB(1, 0, 0).mix(Color4.ofRGB(0, 0, 1), 0.1)).objEq(Color4.ofRGB(0.9, 0, 0.1));
+	});
+
+	it('should mix red and green to get yellow', () => {
+		expect(Color4.ofRGB(1, 0, 0).mix(Color4.ofRGB(0, 1, 0), 0.3)).objEq(
+			Color4.ofRGB(0.7, 0.3, 0)
+		);
+	});
 });

--- a/src/Color4.ts
+++ b/src/Color4.ts
@@ -129,6 +129,28 @@ export default class Color4 {
 		return this.toHexString() === other.toHexString();
 	}
 
+	/**
+	 * If `fractionTo` is not in the range [0, 1], it will be clamped to the nearest number
+	 * in that range. For example, `a.mix(b, -1)` is equivalent to `a.mix(b, 0)`.
+	 * 
+	 * @returns a color `fractionTo` of the way from this color to `other`.
+	 * 
+	 * @example
+	 * ```ts
+	 * Color4.ofRGB(1, 0, 0).mix(Color4.ofRGB(0, 1, 0), 0.1) // -> Color4(0.9, 0.1, 0)
+	 * ```
+	 */
+	public mix(other: Color4, fractionTo: number): Color4 {
+		fractionTo = Math.min(Math.max(fractionTo, 0), 1);
+		const fractionOfThis = 1 - fractionTo;
+		return new Color4(
+			this.r * fractionOfThis + other.r * fractionTo,
+			this.g * fractionOfThis + other.g * fractionTo,
+			this.b * fractionOfThis + other.b * fractionTo,
+			this.a * fractionOfThis + other.a * fractionTo,
+		);
+	}
+
 	private hexString: string|null = null;
 
 	/**

--- a/src/toolbar/IconProvider.ts
+++ b/src/toolbar/IconProvider.ts
@@ -401,6 +401,12 @@ export default class IconProvider {
 			C 80.47,98.32 50.5,93.5 20,${trailStartEndY} Z
 		`;
 
+		const colorBubblePath = `
+			M 72.45,35.67
+			A 10,15 41.8 0 1 55,40.2 10,15 41.8 0 1 57.55,22.3 10,15 41.8 0 1 75,17.8 10,15 41.8 0 1 72.5,35.67
+			Z
+		`;
+
 		let gripMainPath = 'M 85,-25 25,35 h 10 v 10 h 10 v 10 h 10 v 10 h 10 l -5,10 60,-60 z';
 		let gripShadow1Path = 'M 25,35 H 35 L 90,-15 85,-25 Z';
 		let gripShadow2Path = 'M 60,75 65,65 H 55 l 55,-55 10,5 z';
@@ -456,12 +462,12 @@ export default class IconProvider {
 
 			<!-- color bubble -->
 			<path
+				fill="${checkerboardPatternRef}"
+				d="${colorBubblePath}"
+			/>
+			<path
 				fill="${color}"
-				d="
-					M 72.45,35.67
-					A 10,15 41.8 0 1 55,40.2 10,15 41.8 0 1 57.55,22.3 10,15 41.8 0 1 75,17.8 10,15 41.8 0 1 72.5,35.67
-					Z
-				"
+				d="${colorBubblePath}"
 			/>
 		`;
 

--- a/src/toolbar/IconProvider.ts
+++ b/src/toolbar/IconProvider.ts
@@ -383,52 +383,86 @@ export default class IconProvider {
 		return icon;
 	}
 	
-	public makePenIcon(tipThickness: number, color: string|Color4, roundedTip?: boolean): IconType {
+	public makePenIcon(strokeSize: number, color: string|Color4, rounded?: boolean): IconType {
 		if (color instanceof Color4) {
 			color = color.toHexString();
 		}
 	
 		const icon = document.createElementNS(svgNamespace, 'svg');
 		icon.setAttribute('viewBox', '0 0 100 100');
-	
-		const halfThickness = tipThickness / 2;
-	
-		// Draw a pen-like shape
-		const penTipLeft = 50 - halfThickness;
-		const penTipRight = 50 + halfThickness;
+		const tipThickness = Math.sqrt(strokeSize / 2);
 
-		let tipCenterPrimaryPath = `L${penTipLeft},95 L${penTipRight},90`;
-		let tipCenterBackgroundPath = `L${penTipLeft},85 L${penTipRight},83`;
+		const inkTipPath = `M ${15 - tipThickness},${80 - tipThickness} 15,${80 + tipThickness} 30,83 15,65 Z`;
+		const trailStartEndY = 82 + tipThickness / 3;
+		const inkTrailPath = `
+			m ${15 - tipThickness},${trailStartEndY}
+			c 35,10 55,15 60,30
+			l ${35 + tipThickness},${-10 - tipThickness}
+			C 80.47,98.32 50.5,93.5 20,${trailStartEndY} Z
+		`;
 
-		if (roundedTip) {
-			tipCenterPrimaryPath = `L${penTipLeft},95 q${halfThickness},10 ${2 * halfThickness},-5`;
-			tipCenterBackgroundPath = `L${penTipLeft},87 q${halfThickness},10 ${2 * halfThickness},-3`;
+		let gripMainPath = 'M 85,-25 25,35 h 10 v 10 h 10 v 10 h 10 v 10 h 10 l -5,10 60,-60 z';
+		let gripShadow1Path = 'M 25,35 H 35 L 90,-15 85,-25 Z';
+		let gripShadow2Path = 'M 60,75 65,65 H 55 l 55,-55 10,5 z';
+
+		if (rounded) {
+			gripMainPath = 'M 85,-25 25,35 c 15,0 40,30 35,40 l 60,-60 z';
+			gripShadow1Path = 'm 25,35 c 3.92361,0.384473 7.644275,0.980572 10,3 l 55,-53 -5,-10 z';
+			gripShadow2Path = 'M 60,75 C 61,66 59,65 56,59 l 54,-54 10,10 z';
 		}
 
-		const primaryStrokeTipPath = `M14,63 ${tipCenterPrimaryPath} L88,60 Z`;
-		const backgroundStrokeTipPath = `M14,63 ${tipCenterBackgroundPath} L88,60 Z`;
+		const ink = `
+			<path
+				fill="${checkerboardPatternRef}"
+				d="${inkTipPath}"
+			/>
+			<path
+				fill="${checkerboardPatternRef}"
+				d="${inkTrailPath}"
+			/>
+			<path
+				fill="${color}"
+				d="${inkTipPath}"
+			/>
+			<path
+				fill="${color}"
+				d="${inkTrailPath}"
+			/>
+		`;
+
+		const penTip = `
+			<path
+				fill="#f4d7d7"
+				stroke="${color}"
+				d="M 25,35 ${10 - tipThickness / 4},${70 - tipThickness / 2} 20,75 25,85 60,75 70,55 45,25 Z"
+			/>
+		`;
+
+		const grip = `
+			<path
+				${iconColorStrokeFill}
+				d="${gripMainPath}"
+			/>
+
+			<!-- shadows -->
+			<path
+				fill="rgba(150, 150, 150, 0.3)"
+				d="${gripShadow1Path}"
+			/>
+			<path
+				fill="rgba(100, 100, 100, 0.2)"
+				d="${gripShadow2Path}"
+			/>
+		`;
 
 		icon.innerHTML = `
 		<defs>
 			${checkerboardPatternDef}
 		</defs>
 		<g>
-			<!-- Pen grip -->
-			<path
-				d='M10,10 L90,10 L90,60 L${50 + halfThickness},80 L${50 - halfThickness},80 L10,60 Z'
-				${iconColorStrokeFill}
-			/>
-		</g>
-		<g>
-			<!-- Checkerboard background for slightly transparent pens -->
-			<path d='${backgroundStrokeTipPath}' fill='${checkerboardPatternRef}'/>
-	
-			<!-- Actual pen tip -->
-			<path
-				d='${primaryStrokeTipPath}'
-				fill='${color}'
-				stroke='${color}'
-			/>
+			${ink}
+			${penTip}
+			${grip}
 		</g>
 		`;
 		return icon;

--- a/src/toolbar/IconProvider.ts
+++ b/src/toolbar/IconProvider.ts
@@ -390,15 +390,21 @@ export default class IconProvider {
 	
 		const icon = document.createElementNS(svgNamespace, 'svg');
 		icon.setAttribute('viewBox', '0 0 100 100');
-		const tipThickness = Math.sqrt(strokeSize / 2);
+		const tipThickness = strokeSize / 2;
 
-		const inkTipPath = `M ${15 - tipThickness},${80 - tipThickness} 15,${80 + tipThickness} 30,83 15,65 Z`;
-		const trailStartEndY = 82 + tipThickness / 3;
+		const inkTipPath = `
+			M ${15 - tipThickness},${80 - tipThickness}
+			  ${15 - tipThickness},${80 + tipThickness}
+			  30,83
+			  15,65
+			Z
+		`;
+		const trailStartEndY = 80 + tipThickness;
 		const inkTrailPath = `
-			m ${15 - tipThickness},${trailStartEndY}
+			m ${15 - tipThickness * 1.1},${trailStartEndY}
 			c 35,10 55,15 60,30
-			l ${35 + tipThickness},${-10 - tipThickness}
-			C 80.47,98.32 50.5,93.5 20,${trailStartEndY} Z
+			l ${35 + tipThickness * 1.2},${-10 - tipThickness}
+			C 80.47,98.32 50.5,${90 + tipThickness} 20,${trailStartEndY} Z
 		`;
 
 		const colorBubblePath = `
@@ -416,6 +422,13 @@ export default class IconProvider {
 			gripShadow1Path = 'm 25,35 c 3.92361,0.384473 7.644275,0.980572 10,3 l 55,-53 -5,-10 z';
 			gripShadow2Path = 'M 60,75 C 61,66 59,65 56,59 l 54,-54 10,10 z';
 		}
+
+		const penTipPath = `M 25,35 ${10 - tipThickness / 4},${70 - tipThickness / 2} 20,75 25,85 60,75 70,55 45,25 Z`;
+
+		const pencilTipColor = Color4.fromHex('#f4d7d7');
+		const tipColor = pencilTipColor.mix(
+			Color4.fromString(color), tipThickness / 40 - 0.1
+		).toHexString();
 
 		const ink = `
 			<path
@@ -438,9 +451,13 @@ export default class IconProvider {
 
 		const penTip = `
 			<path
-				fill="#f4d7d7"
+				fill="${checkerboardPatternRef}"
+				d="${penTipPath}"
+			/>
+			<path
+				fill="${tipColor}"
 				stroke="${color}"
-				d="M 25,35 ${10 - tipThickness / 4},${70 - tipThickness / 2} 20,75 25,85 60,75 70,55 45,25 Z"
+				d="${penTipPath}"
 			/>
 		`;
 

--- a/src/toolbar/IconProvider.ts
+++ b/src/toolbar/IconProvider.ts
@@ -453,6 +453,16 @@ export default class IconProvider {
 				fill="rgba(100, 100, 100, 0.2)"
 				d="${gripShadow2Path}"
 			/>
+
+			<!-- color bubble -->
+			<path
+				fill="${color}"
+				d="
+					M 72.45,35.67
+					A 10,15 41.8 0 1 55,40.2 10,15 41.8 0 1 57.55,22.3 10,15 41.8 0 1 75,17.8 10,15 41.8 0 1 72.5,35.67
+					Z
+				"
+			/>
 		`;
 
 		icon.innerHTML = `


### PR DESCRIPTION
# Summary
Updates the previous pen icons to make them look more like pens/pencils. The new icons still respond to the current pen size/color, but not as much as previously.

# Screenshots/other information
<!--
	If applicable, please include screenshots/screen recordings/other information that may help contributors review this pull request.
-->
**Before:**
![pen icons in light mode, before changes, each looks somewhat like a boat](https://user-images.githubusercontent.com/46334387/213048124-644f5743-4795-4505-ac1f-9a17353a9226.png)
![pen icons in dark mode, before changes](https://user-images.githubusercontent.com/46334387/213048172-4faf3239-72cb-4978-964a-fa2078f9765f.png)


**After:**
![new pen icons in light mode](https://user-images.githubusercontent.com/46334387/213047863-0792a1f2-6068-4d5d-a73d-a7bf41510e12.png)
![new pen icons in dark mode](https://user-images.githubusercontent.com/46334387/213047916-b2be27b6-513c-4a97-a52e-28d51995a2f3.png)

