### PR TITLE
Attempt to fix strokes canceling on pen up on some devices

### DIFF
--- a/packages/js-draw/src/testing/getUniquePointerId.ts
+++ b/packages/js-draw/src/testing/getUniquePointerId.ts
@@ -1,0 +1,18 @@
+import Pointer from '../Pointer';
+
+/** Returns the smallest ID not used by the pointers in the given list. */
+const getUniquePointerId = (pointers: Pointer[]) => {
+	let ptrId = 0;
+
+	const pointerIds = pointers.map(ptr => ptr.id);
+	pointerIds.sort();
+	for (const pointerId of pointerIds) {
+		if (ptrId === pointerId) {
+			ptrId = pointerId + 1;
+		}
+	}
+
+	return ptrId;
+};
+
+export default getUniquePointerId;

--- a/packages/js-draw/src/testing/sendPenEvent.ts
+++ b/packages/js-draw/src/testing/sendPenEvent.ts
@@ -2,6 +2,7 @@ import Editor from '../Editor';
 import { Point2 } from '../math/Vec2';
 import Pointer from '../Pointer';
 import { InputEvtType } from '../types';
+import getUniquePointerId from './getUniquePointerId';
 
 /**
  * Dispatch a pen event to the currently selected tool.
@@ -16,8 +17,10 @@ const sendPenEvent = (
 
 	allPointers?: Pointer[]
 ) => {
+	const id = getUniquePointerId(allPointers ?? []);
+
 	const mainPointer = Pointer.ofCanvasPoint(
-		point, eventType !== InputEvtType.PointerUpEvt, editor.viewport
+		point, eventType !== InputEvtType.PointerUpEvt, editor.viewport, id
 	);
 
 	editor.toolController.dispatchInputEvent({
@@ -27,5 +30,7 @@ const sendPenEvent = (
 		],
 		current: mainPointer,
 	});
+
+	return mainPointer;
 };
 export default sendPenEvent;

--- a/packages/js-draw/src/testing/sendTouchEvent.ts
+++ b/packages/js-draw/src/testing/sendTouchEvent.ts
@@ -2,6 +2,7 @@ import Editor from '../Editor';
 import { Vec2 } from '../math/Vec2';
 import Pointer, { PointerDevice } from '../Pointer';
 import { InputEvtType } from '../types';
+import getUniquePointerId from './getUniquePointerId';
 
 /**
  * Dispatch a touch event to the currently selected tool. Intended for unit tests.
@@ -47,17 +48,9 @@ const sendTouchEvent = (
 ) => {
 	const canvasPos = editor.viewport.screenToCanvas(screenPos);
 
-	let ptrId = 0;
-	let maxPtrId = 0;
-
 	// Get a unique ID for the main pointer
 	// (try to use id=0, but don't use it if it's already in use).
-	for (const pointer of allOtherPointers ?? []) {
-		maxPtrId = Math.max(pointer.id, maxPtrId);
-		if (pointer.id === ptrId) {
-			ptrId = maxPtrId + 1;
-		}
-	}
+	const ptrId = getUniquePointerId(allOtherPointers ?? []);
 
 	const mainPointer = Pointer.ofCanvasPoint(
 		canvasPos, eventType !== InputEvtType.PointerUpEvt, editor.viewport, ptrId, PointerDevice.Touch

--- a/packages/js-draw/src/tools/BaseTool.ts
+++ b/packages/js-draw/src/tools/BaseTool.ts
@@ -5,9 +5,21 @@ export default abstract class BaseTool implements PointerEvtListener {
 	private enabled: boolean = true;
 	private group: ToolEnabledGroup|null = null;
 
+	/**
+	 * Returns true iff the tool handled the event and thus should receive additional
+	 * events.
+	 */
 	public onPointerDown(_event: PointerEvt): boolean { return false; }
 	public onPointerMove(_event: PointerEvt) { }
-	public onPointerUp(_event: PointerEvt) { }
+
+	/**
+	 * Returns true iff there are additional pointers down and the tool should
+	 * remain active to handle the additional events.
+	 *
+	 * For most purposes, this should return `false` or nothing.
+	 */
+	public onPointerUp(_event: PointerEvt): boolean|void { }
+
 	public onGestureCancel() { }
 
 	protected constructor(private notifier: EditorNotifier, public readonly description: string) {
@@ -31,6 +43,15 @@ export default abstract class BaseTool implements PointerEvtListener {
 
 	public onKeyUp(_event: KeyUpEvent): boolean {
 		return false;
+	}
+
+	/**
+	 * Return true if, while this tool is active, `_event` can be delivered to
+	 * another tool that is higher priority than this.
+	 * @internal May be renamed
+	 */
+	public eventCanBeDeliveredToNonActiveTool(_event: PointerEvt) {
+		return true;
 	}
 
 	public setEnabled(enabled: boolean) {


### PR DESCRIPTION
# Summary
Disallows touch events from canceling pen event **strokes**. (Does this change also need to apply to the eraser and selection tools?)

# Testing <!-- (if applicable) -->
- [x] Verify this doesn't break pen drawing
- [x] Verify this doesn't break touchscreen drawing
- [x] Verify this doesn't break other tools (e.g. panning/selecting/erasing)


May resolve #23
