### PR TITLE
Add help screen

### DIFF
--- a/packages/js-draw/src/testing/sendHtmlSwipe.ts
+++ b/packages/js-draw/src/testing/sendHtmlSwipe.ts
@@ -1,0 +1,32 @@
+import { Point2 } from '@js-draw/math';
+
+/** Swipes `element` using HTML pointer events. */
+const sendHtmlSwipe = async (
+	element: HTMLElement,
+	start: Point2,
+	end: Point2,
+	timeMs: number = 300,
+) => {
+	element.dispatchEvent(
+		new PointerEvent('pointerdown', { isPrimary: true, clientX: start.x, clientY: start.y, })
+	);
+
+	const step = 0.1;
+	for (let i = 0; i < 1; i += step) {
+		await jest.advanceTimersByTimeAsync(timeMs * step);
+
+		const currentPoint = start.lerp(end, i);
+		element.dispatchEvent(
+			new PointerEvent(
+				'pointermove',
+				{ isPrimary: true, clientX: currentPoint.x, clientY: currentPoint.y, },
+			),
+		);
+	}
+
+	element.dispatchEvent(
+		new PointerEvent('pointerup', { isPrimary: true, clientX: end.x, clientY: end.y, })
+	);
+};
+
+export default sendHtmlSwipe;

--- a/packages/js-draw/src/toolbar/EdgeToolbar.scss
+++ b/packages/js-draw/src/toolbar/EdgeToolbar.scss
@@ -312,6 +312,10 @@
 		--button-label-hover-offset-y: var(--button-size);
 		@include labelVisibleOnHover.label-visible-on-hover('label > .button-label-text');
 	}
+
+	.toolbar-help-overlay-button {
+		align-items: last baseline;
+	}
 }
 
 .toolbar-edgemenu-container .toolbar-edgemenu {

--- a/packages/js-draw/src/toolbar/EdgeToolbar.scss
+++ b/packages/js-draw/src/toolbar/EdgeToolbar.scss
@@ -436,6 +436,11 @@
 			margin-top: 5px;
 			min-height: 35px;
 
+			// No extra space above the first
+			&:first-child {
+				margin-top: 0;
+			}
+
 			// Align inputs (assumes labels come first)
 			& > label {
 				padding-right: 35px;

--- a/packages/js-draw/src/toolbar/EdgeToolbar.scss
+++ b/packages/js-draw/src/toolbar/EdgeToolbar.scss
@@ -385,6 +385,12 @@
 		}
 	}
 
+	.toolbar-help-overlay-button > .button {
+		bottom: 0;
+		margin-right: 10px;
+		margin-bottom: -5px;
+	}
+
 	// Toolbar buttons within the menu
 	.toolbar-toolContainer {
 		display: block;

--- a/packages/js-draw/src/toolbar/EdgeToolbar.scss
+++ b/packages/js-draw/src/toolbar/EdgeToolbar.scss
@@ -385,12 +385,6 @@
 		}
 	}
 
-	.toolbar-help-overlay-button > .button {
-		bottom: 0;
-		margin-right: 10px;
-		margin-bottom: -5px;
-	}
-
 	// Toolbar buttons within the menu
 	.toolbar-toolContainer {
 		display: block;

--- a/packages/js-draw/src/toolbar/IconProvider.ts
+++ b/packages/js-draw/src/toolbar/IconProvider.ts
@@ -884,6 +884,34 @@ export default class IconProvider {
 		`);
 	}
 
+	public makeHelpIcon(): IconElemType {
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		svg.innerHTML = `
+			<circle
+				style="stroke-width:1.587; stroke: var(--icon-color);"
+				fill="none"
+				cx="13.23"
+				cy="13.23"
+				r="11.9"
+			/>
+			<path
+				style="stroke-width: 3; stroke-linecap: butt; stroke: var(--icon-color);"
+				fill="none"
+				d="M 9.26,6.61 C 18.7,3.25 19.95,10.4 14.3,13.4 c -1.15,0.61 -1.32,1.32 -1.32,2.65 v 2.12"
+			/>
+			<circle
+				style="fill: var(--icon-color);"
+				cx="13"
+				cy="21.32"
+				r="1.9"
+			/>
+		`;
+		svg.setAttribute('viewBox', '0 0 26.46 26.46');
+		svg.setAttribute('width', '100');
+		svg.setAttribute('height', '100');
+		return svg;
+	}
+
 	/**
 	 * @param pathData - SVG path data (e.g. `m10,10l30,30z`)
 	 * @param fill - A valid CSS color (e.g. `var(--icon-color)` or `#f0f`). This can be `none`.

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -152,7 +152,7 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 	penDropdown__colorHelpText: 'Changes the pen\'s color',
 	penDropdown__thicknessHelpText:
 		'Changes the pen\'s size.\n\nZooming in or out keeps the pen\'s visible size the same (it changes the size of the pen in the image.)',
-	penDropdown__penTypeHelpText: 'Changes the pen style.\n\nEither a “pen tip” or a “pen shape” can be selected.',
+	penDropdown__penTypeHelpText: 'Changes the pen style.\n\nChoosing a “pen tip” style draws freehand lines. Choosing a “shape” draws shapes.',
 	penDropdown__autocorrectHelpText:
 		'Converts approximate freehand lines and rectangles to perfect ones.\n\nThe pen must be held stationary at the end of a stroke to trigger a correction.',
 	penDropdown__stabilizationHelpText:

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -152,7 +152,7 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 	errorImageHasZeroSize: 'Error: Image has zero size',
 
 	// Help text
-	penDropdown__baseHelpText: 'This tool draws shapes or freehand lines. The settings below apply to this pen.',
+	penDropdown__baseHelpText: 'This tool draws shapes or freehand lines.',
 	penDropdown__colorHelpText: 'Changes the pen\'s color',
 	penDropdown__thicknessHelpText:
 		'Changes the thickness of strokes drawn by the pen.',
@@ -162,7 +162,7 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 	penDropdown__stabilizationHelpText:
 		'Draws smoother strokes.\n\nThis also adds a short delay between the mouse/stylus and the stroke.',
 	handDropdown__baseHelpText:
-		'This tool is responsible for scrolling, rotating, and zooming the editor. Its behavior can be configured below.',
+		'This tool is responsible for scrolling, rotating, and zooming the editor.',
 	handDropdown__zoomInHelpText: 'Zooms in.',
 	handDropdown__zoomOutHelpText: 'Zooms out.',
 	handDropdown__resetViewHelpText:

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -74,6 +74,10 @@ export interface ToolbarLocalization extends ToolbarUtilsLocalization {
 	handDropdown__resetViewHelpText: string;
 	handDropdown__touchPanningHelpText: string;
 	handDropdown__lockRotationHelpText: string;
+	selectionDropdown__resizeToHelpText: string;
+	selectionDropdown__deleteHelpText: string;
+	selectionDropdown__duplicateHelpText: string;
+	selectionDropdown__changeColorHelpText: string;
 	colorPickerPipetteHelpText: string;
 	colorPickerToggleHelpText: string;
 
@@ -173,6 +177,10 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 		'When enabled, touch gestures move the image rather than select or draw.',
 	handDropdown__lockRotationHelpText:
 		'When enabled, prevents touch gestures from rotating the screen.',
+	selectionDropdown__resizeToHelpText: 'Crops the drawing to the size of what\'s currently selected.\n\nIf auto-resize is enabled, it will be disabled.',
+	selectionDropdown__deleteHelpText: 'Erases selected items.',
+	selectionDropdown__duplicateHelpText: 'Makes a copy of selected items.',
+	selectionDropdown__changeColorHelpText: 'Changes the color of selected items.',
 	colorPickerPipetteHelpText: 'Picks a color from the screen.',
 	colorPickerToggleHelpText: 'Opens/closes the color picker.',
 

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -74,10 +74,16 @@ export interface ToolbarLocalization extends ToolbarUtilsLocalization {
 	handDropdown__resetViewHelpText: string;
 	handDropdown__touchPanningHelpText: string;
 	handDropdown__lockRotationHelpText: string;
+	selectionDropdown__baseHelpText: string;
 	selectionDropdown__resizeToHelpText: string;
 	selectionDropdown__deleteHelpText: string;
 	selectionDropdown__duplicateHelpText: string;
 	selectionDropdown__changeColorHelpText: string;
+	pageDropdown__baseHelpText: string;
+	pageDropdown__backgroundColorHelpText: string;
+	pageDropdown__gridCheckboxHelpText: string;
+	pageDropdown__aboutButtonHelpText: string;
+	pageDropdown__autoresizeCheckboxHelpText: string;
 	colorPickerPipetteHelpText: string;
 	colorPickerToggleHelpText: string;
 
@@ -177,10 +183,16 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 		'When enabled, touch gestures move the image rather than select or draw.',
 	handDropdown__lockRotationHelpText:
 		'When enabled, prevents touch gestures from rotating the screen.',
+	selectionDropdown__baseHelpText: 'Selects content and manipulates the selection',
 	selectionDropdown__resizeToHelpText: 'Crops the drawing to the size of what\'s currently selected.\n\nIf auto-resize is enabled, it will be disabled.',
 	selectionDropdown__deleteHelpText: 'Erases selected items.',
 	selectionDropdown__duplicateHelpText: 'Makes a copy of selected items.',
 	selectionDropdown__changeColorHelpText: 'Changes the color of selected items.',
+	pageDropdown__baseHelpText: 'Controls the drawing canvas\' background color, pattern, and size.',
+	pageDropdown__backgroundColorHelpText: 'Changes the background color of the drawing canvas.',
+	pageDropdown__gridCheckboxHelpText: 'Controls whether the drawing canvas has a background grid pattern.',
+	pageDropdown__autoresizeCheckboxHelpText: 'When checked, the page grows to fit the drawing.\n\nWhen unchecked, the page is visible and its size can be set manually.',
+	pageDropdown__aboutButtonHelpText: 'Shows version, debug, and other information.',
 	colorPickerPipetteHelpText: 'Picks a color from the screen.',
 	colorPickerToggleHelpText: 'Opens/closes the color picker.',
 

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -155,7 +155,7 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 	penDropdown__baseHelpText: 'This tool draws shapes or freehand lines. The settings below apply to this pen.',
 	penDropdown__colorHelpText: 'Changes the pen\'s color',
 	penDropdown__thicknessHelpText:
-		'Changes the pen\'s size.\n\nZooming in or out keeps the pen\'s visible size the same (it changes the size of the pen in the image.)',
+		'Changes the thickness of strokes drawn by the pen.',
 	penDropdown__penTypeHelpText: 'Changes the pen style.\n\nChoosing a “pen tip” style draws freehand lines. Choosing a “shape” draws shapes.',
 	penDropdown__autocorrectHelpText:
 		'Converts approximate freehand lines and rectangles to perfect ones.\n\nThe pen must be held stationary at the end of a stroke to trigger a correction.',

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -160,7 +160,7 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 	penDropdown__colorHelpText: 'Changes the pen\'s color',
 	penDropdown__thicknessHelpText:
 		'Changes the thickness of strokes drawn by the pen.',
-	penDropdown__penTypeHelpText: 'Changes the pen style.\n\nChoosing a “pen tip” style draws freehand lines. Choosing a “shape” draws shapes.',
+	penDropdown__penTypeHelpText: 'Changes the pen style.\n\nEither a “pen tip” style or “shape” can be chosen. Choosing a “pen tip” style draws freehand lines. Choosing a “shape” draws shapes.',
 	penDropdown__autocorrectHelpText:
 		'Converts approximate freehand lines and rectangles to perfect ones.\n\nThe pen must be held stationary at the end of a stroke to trigger a correction.',
 	penDropdown__stabilizationHelpText:

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -74,7 +74,8 @@ export interface ToolbarLocalization extends ToolbarUtilsLocalization {
 	handDropdown__resetViewHelpText: string;
 	handDropdown__touchPanningHelpText: string;
 	handDropdown__lockRotationHelpText: string;
-
+	colorPickerPipetteHelpText: string;
+	colorPickerToggleHelpText: string;
 
 	// closeSidebar is used for accessibility in a button label.
 	closeSidebar: (toolName: string)=>string;
@@ -172,6 +173,8 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 		'When enabled, touch gestures move the image rather than select or draw.',
 	handDropdown__lockRotationHelpText:
 		'When enabled, prevents touch gestures from rotating the screen.',
+	colorPickerPipetteHelpText: 'Picks a color from the screen.',
+	colorPickerToggleHelpText: 'Opens/closes the color picker.',
 
 	closeSidebar: (toolName: string) => `Close sidebar for ${toolName}`,
 	dropdownShown: (toolName) => `Menu for ${toolName} shown`,

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -68,7 +68,10 @@ export interface ToolbarLocalization extends ToolbarUtilsLocalization {
 	penDropdown__autocorrectHelpText: string;
 	penDropdown__stabilizationHelpText: string;
 	handDropdown__baseHelpText: string;
-	handDropdown__zoomHelpText: string;
+	handDropdown__zoomDisplayHelpText: string;
+	handDropdown__zoomInHelpText: string;
+	handDropdown__zoomOutHelpText: string;
+	handDropdown__resetViewHelpText: string;
 	handDropdown__touchPanningHelpText: string;
 	handDropdown__lockRotationHelpText: string;
 
@@ -159,8 +162,12 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 		'Draws smoother strokes.\n\nThis also adds a short delay between the mouse/stylus and the stroke.',
 	handDropdown__baseHelpText:
 		'This tool is responsible for scrolling, rotating, and zooming the editor. Its behavior can be configured below.',
-	handDropdown__zoomHelpText:
-		'Increase/decrease the zoom or reset zoom and scroll.',
+	handDropdown__zoomInHelpText: 'Zooms in.',
+	handDropdown__zoomOutHelpText: 'Zooms out.',
+	handDropdown__resetViewHelpText:
+		'Resets the zoom level to 100% and resets scroll.',
+	handDropdown__zoomDisplayHelpText:
+		'Shows the current zoom level. 100% shows the image at its actual size.',
 	handDropdown__touchPanningHelpText:
 		'When enabled, touch gestures move the image rather than select or draw.',
 	handDropdown__lockRotationHelpText:

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -1,6 +1,6 @@
+import { ToolbarUtilsLocalization, defaultToolbarUtilsLocalization } from './utils/localization';
 
-
-export interface ToolbarLocalization {
+export interface ToolbarLocalization extends ToolbarUtilsLocalization {
 	fontLabel: string;
 	textSize: string;
 	touchPanning: string;
@@ -72,6 +72,8 @@ export interface ToolbarLocalization {
 }
 
 export const defaultToolbarLocalization: ToolbarLocalization = {
+	...defaultToolbarUtilsLocalization,
+
 	pen: 'Pen',
 	eraser: 'Eraser',
 	select: 'Select',

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -67,6 +67,11 @@ export interface ToolbarLocalization extends ToolbarUtilsLocalization {
 	penDropdown__penTypeHelpText: string;
 	penDropdown__autocorrectHelpText: string;
 	penDropdown__stabilizationHelpText: string;
+	handDropdown__baseHelpText: string;
+	handDropdown__zoomHelpText: string;
+	handDropdown__touchPanningHelpText: string;
+	handDropdown__lockRotationHelpText: string;
+
 
 	// closeSidebar is used for accessibility in a button label.
 	closeSidebar: (toolName: string)=>string;
@@ -152,6 +157,14 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 		'Converts approximate freehand lines and rectangles to perfect ones.\n\nThe pen must be held stationary at the end of a stroke to trigger a correction.',
 	penDropdown__stabilizationHelpText:
 		'Draws smoother strokes.\n\nThis also adds a short delay between the mouse/stylus and the stroke.',
+	handDropdown__baseHelpText:
+		'This tool is responsible for scrolling, rotating, and zooming the editor. Its behavior can be configured below.',
+	handDropdown__zoomHelpText:
+		'Increase/decrease the zoom or reset zoom and scroll.',
+	handDropdown__touchPanningHelpText:
+		'When enabled, touch gestures move the image rather than select or draw.',
+	handDropdown__lockRotationHelpText:
+		'When enabled, prevents touch gestures from rotating the screen.',
 
 	closeSidebar: (toolName: string) => `Close sidebar for ${toolName}`,
 	dropdownShown: (toolName) => `Menu for ${toolName} shown`,

--- a/packages/js-draw/src/toolbar/localization.ts
+++ b/packages/js-draw/src/toolbar/localization.ts
@@ -60,6 +60,14 @@ export interface ToolbarLocalization extends ToolbarUtilsLocalization {
 
 	errorImageHasZeroSize: string;
 
+	// Help text
+	penDropdown__baseHelpText: string;
+	penDropdown__colorHelpText: string;
+	penDropdown__thicknessHelpText: string;
+	penDropdown__penTypeHelpText: string;
+	penDropdown__autocorrectHelpText: string;
+	penDropdown__stabilizationHelpText: string;
+
 	// closeSidebar is used for accessibility in a button label.
 	closeSidebar: (toolName: string)=>string;
 	dropdownShown: (toolName: string)=> string;
@@ -132,6 +140,18 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 
 	paste: 'Paste',
 
+	errorImageHasZeroSize: 'Error: Image has zero size',
+
+	// Help text
+	penDropdown__baseHelpText: 'This tool draws shapes or freehand lines. The settings below apply to this pen.',
+	penDropdown__colorHelpText: 'Changes the pen\'s color',
+	penDropdown__thicknessHelpText:
+		'Changes the pen\'s size.\n\nZooming in or out keeps the pen\'s visible size the same (it changes the size of the pen in the image.)',
+	penDropdown__penTypeHelpText: 'Changes the pen style.\n\nEither a “pen tip” or a “pen shape” can be selected.',
+	penDropdown__autocorrectHelpText:
+		'Converts approximate freehand lines and rectangles to perfect ones.\n\nThe pen must be held stationary at the end of a stroke to trigger a correction.',
+	penDropdown__stabilizationHelpText:
+		'Draws smoother strokes.\n\nThis also adds a short delay between the mouse/stylus and the stroke.',
 
 	closeSidebar: (toolName: string) => `Close sidebar for ${toolName}`,
 	dropdownShown: (toolName) => `Menu for ${toolName} shown`,
@@ -141,6 +161,5 @@ export const defaultToolbarLocalization: ToolbarLocalization = {
 	colorChangedAnnouncement: (color: string) => `Color changed to ${color}`,
 	imageSize: (size: number, units: string) => `Image size: ${size} ${units}`,
 
-	errorImageHasZeroSize: 'Error: Image has zero size',
 	imageLoadError: (message: string)=> `Error loading image: ${message}`,
 };

--- a/packages/js-draw/src/toolbar/toolbar.scss
+++ b/packages/js-draw/src/toolbar/toolbar.scss
@@ -9,3 +9,5 @@
 @use "./AbstractToolbar.scss";
 @use "./EdgeToolbar.scss";
 @use "./DropdownToolbar.scss";
+
+@use "./utils/HelpDisplay.scss";

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -84,6 +84,7 @@
 		display: flex;
 		align-items: center;
 		flex-grow: 1;
+		touch-action: none;
 
 		> .label {
 			@extend .with-text-shadow;
@@ -122,15 +123,14 @@
 			z-index: -1;
 
 			border-radius: 10px;
-			background-color: var(--background-color-1);
-			box-shadow: 0 0 3px rgba(100, 100, 100, 0.5);
-			
-			> * {
-				margin: 0;
-			}
 
 			* {
 				pointer-events: none !important;
+			}
+
+			> * {
+				margin: 0;
+				opacity: 0.01;
 				transition: 0.3s ease opacity !important;
 			}
 
@@ -144,22 +144,35 @@
 				z-index: 2;
 				touch-action: none;
 
-				&:hover, &:active {
-					filter: opacity(0.5);
+				&.has-long-press-or-hover {
+					opacity: 0.5 !important;
 
 					> * {
-						opacity: 0 !important;
+						opacity: 0.01 !important;
 						transition: 0s ease opacity !important;
 					}
 				}
 			}
 
-			filter: opacity(0);
-			&.-active {
-				filter: opacity(1);
+			&.-clickable.has-long-press-or-hover, &.-active {
+				background-color: var(--background-color-1);
 			}
 
-			transition: 0.3s ease filter;
+			opacity: 0.01;
+			background-color: rgba(100, 100, 100, 0.01);
+			box-shadow: none;
+
+			&.-active {
+				opacity: 1;
+				background-color: var(--background-color-1);
+				box-shadow: 0 0 3px rgba(100, 100, 100, 0.5);
+
+				> * {
+					opacity: 1 !important;
+				}
+			}
+
+			transition: 0.3s ease opacity, 0.3s ease background-color;
 		}
 	}
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -1,0 +1,142 @@
+
+.toolbar-help-overlay {
+	width: 100%;
+	height: 100%;
+	border: none;
+	margin: 0;
+	padding: 0;
+	z-index: 5;
+
+	// TODO: Use theme colors
+	color: white;
+	--icon-color: white;
+	background-color: rgba(0, 0, 0, 0.8);
+
+	backdrop-filter: blur(1px);
+	-webkit-backdrop-filter: blur(1px);
+
+	display: flex;
+	flex-direction: column;
+
+	// For drag transitions
+	transition: 0.3s ease transform;
+	&.-dragging {
+		transition: none;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
+	.with-text-shadow {
+		text-shadow: 0 0 3px rgba(20, 20, 20, 0.9);
+	}
+
+	button:not(:disabled) {
+		cursor: pointer;
+	}
+
+	button {
+		@extend .with-text-shadow;
+
+		background: transparent;
+		border: none;
+		color: white;
+
+		border-radius: 15px;
+	}
+
+	.close-button {
+		align-self: flex-start;
+		width: 48px;
+		height: 48px;
+
+		> svg {
+			width: 100%;
+		}
+	}
+
+	.help-page-container {
+		> .label {
+			@extend .with-text-shadow;
+
+			text-align: center;
+			font-size: 20pt;
+			margin-left: 15px;
+			margin-right: 15px;
+		}
+
+		> .cloned-element-container {
+			position: absolute;
+			z-index: -1;
+
+			box-shadow: 0 0 3px rgba(100, 100, 100, 0.5);
+			
+			> * {
+				margin: 0;
+			}
+
+			* {
+				cursor: unset !important;
+			}
+		}
+	}
+
+	.navigation-buttons {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		margin-bottom: 25px;
+
+		> button:disabled {
+			opacity: 0.5;
+		}
+
+		> .next, > .previous {
+			font-size: 1em;
+			padding: 10px;
+			transition: 0.2s ease font-size;
+
+			@media (prefers-reduced-motion: reduce) {
+				transition: none;
+			}
+		}
+
+		&.-has-next > .next {
+			font-size: 1.4em;
+		}
+
+		&.-has-previous > .previous {
+			font-size: 1.4em;
+		}
+
+		> .next::after {
+			content: "❯";
+			margin-left: 3px;
+		}
+
+		> .previous::before {
+			content: "❮";
+			margin-right: 3px;
+		}
+	}
+}
+
+
+.toolbar-element .help-button {
+	float: right;
+	border: 1px solid var(--icon-color);
+	color: var(--icon-color);
+	background-color: var(--background-color-1);
+
+	margin: 15px;
+	margin-top: 0;
+
+	border-radius: 100%;
+	width: 1.2em;
+	height: 1.2em;
+	padding: 0;
+
+	text-align: center;
+	opacity: 0.5;
+}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -70,6 +70,7 @@
 		align-self: flex-start;
 		width: 48px;
 		height: 48px;
+		z-index: 1;
 
 		> svg {
 			width: 100%;
@@ -97,6 +98,8 @@
 			margin-right: 15px;
 			margin-top: 0px;
 
+			z-index: 1;
+
 			&.-large-space-below {
 				margin-top: 0;
 				margin-bottom: auto;
@@ -121,7 +124,7 @@
 
 		> .cloned-element-container {
 			position: absolute;
-			z-index: -1;
+			z-index: 0;
 
 			border-radius: 10px;
 
@@ -139,11 +142,15 @@
 				cursor: unset !important;
 			}
 
+			&.-clickable, &.-background {
+				z-index: 1;
+				touch-action: none;
+			}
+
 			&.-clickable {
 				cursor: pointer;
 
 				z-index: 2;
-				touch-action: none;
 
 				&.has-long-press-or-hover {
 					opacity: 0.5 !important;

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -289,20 +289,27 @@
 	justify-content: end;
 
 	> .button {
-		margin: 4px;
-		margin-top: 0;
+		margin: 0;
+		padding: 5px;
+		padding-top: 0;
+		padding-bottom: 0;
 
-		border-radius: 100%;
-		width: 1.2em;
-		height: 1.2em;
-		padding: 0;
+		box-shadow: none;
 
 		text-align: center;
 		opacity: 0.5;
 
 		> .icon {
-			width: 100%;
-			height: 100%;
+			width: 1.2em;
+			height: 1.2em;
+
+			transition: 0.2s ease filter;
+		}
+
+		&:focus-visible, &:hover {
+			> .icon {
+				filter: drop-shadow(0px 0px 1px var(--shadow-color));
+			}
 		}
 	}
 }

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -15,6 +15,7 @@
 	color: white;
 	--icon-color: white;
 
+	// We use ::backdrop for background styling
 	background-color: transparent;
 
 	&::backdrop {
@@ -27,6 +28,28 @@
 	display: flex;
 	flex-direction: column;
 
+	// Show/hide animations
+	&, &::backdrop {
+		@keyframes transition-in {
+			0% { opacity: 0; }
+			100% { opacity: 1; }
+		}
+		animation: 0.25s ease transition-in;
+	}
+
+	&.-hiding {
+		@keyframes transition-out {
+			0% { opacity: 1; }
+			100% { opacity: 0; }
+		}
+
+		&, &::backdrop {
+			animation: 0.25s ease transition-out;
+			opacity: 0;
+		}
+	}
+
+
 	// For drag transitions
 	transition: 0.3s ease transform;
 	&.-dragging {
@@ -36,6 +59,7 @@
 	@media (prefers-reduced-motion: reduce) {
 		transition: none;
 	}
+
 
 	@media screen and (min-width: 800px) {
 		// Move the navigation buttons to the bottom of the screen
@@ -93,7 +117,7 @@
 
 			flex-grow: 1;
 			text-align: center;
-			font-size: 20pt;
+			font-size: 18.5pt;
 			margin-left: 15px;
 			margin-right: 15px;
 			margin-top: 0px;

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -220,14 +220,14 @@
 	height: 0;
 	position: relative;
 
-	> .button {
-		position: absolute;
-		right: 0;
-		margin: 15px;
-		margin-top: 0;
+	// Use flex so that items reverse in RTL
+	display: flex;
+	justify-content: end;
+	align-items: last baseline;
 
-		border: 1px solid var(--icon-color);
-		color: var(--icon-color);
+	> .button {
+		margin: 4px;
+		margin-top: 0;
 
 		border-radius: 100%;
 		width: 1.2em;
@@ -236,5 +236,10 @@
 
 		text-align: center;
 		opacity: 0.5;
+
+		> .icon {
+			width: 100%;
+			height: 100%;
+		}
 	}
 }

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -300,8 +300,8 @@
 		opacity: 0.5;
 
 		> .icon {
-			width: 1.2em;
-			height: 1.2em;
+			width: 1.18em;
+			height: 1.18em;
 
 			transition: 0.2s ease filter;
 		}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -131,6 +131,7 @@
 
 			* {
 				pointer-events: none !important;
+				transition: 0.3s ease opacity !important;
 			}
 
 			&:not(.-clickable) * {
@@ -142,6 +143,15 @@
 
 				z-index: 2;
 				touch-action: none;
+
+				&:hover, &:active {
+					filter: opacity(0.5);
+
+					> * {
+						opacity: 0 !important;
+						transition: 0s ease opacity !important;
+					}
+				}
 			}
 
 			filter: opacity(0);
@@ -149,7 +159,7 @@
 				filter: opacity(1);
 			}
 
-			transition: 0.1s ease opacity;
+			transition: 0.3s ease filter;
 		}
 	}
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -126,6 +126,10 @@
 			position: absolute;
 			z-index: 0;
 
+			// Prevent selecton on long-press
+			user-select: none;
+			-webkit-user-select: none;
+
 			border-radius: 10px;
 
 			* {

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -49,6 +49,7 @@
 
 	.with-text-shadow {
 		text-shadow: 0 0 3px rgba(20, 20, 20, 0.9);
+		filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, 0.5));
 	}
 
 	button:not(:disabled) {
@@ -172,7 +173,7 @@
 				}
 			}
 
-			transition: 0.3s ease opacity, 0.3s ease background-color;
+			transition: 0.5s ease opacity, 0.5s ease background-color;
 		}
 	}
 
@@ -192,6 +193,7 @@
 			font-size: 1em;
 			padding: 10px;
 			transition: 0.2s ease font-size;
+			z-index: 3;
 
 			@media (prefers-reduced-motion: reduce) {
 				transition: none;

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -6,6 +6,7 @@
 	margin: 0;
 	padding: 0;
 	z-index: 5;
+	touch-action: none;
 
 	// TODO: Use theme colors
 	color: white;
@@ -27,6 +28,16 @@
 	@media (prefers-reduced-motion: reduce) {
 		transition: none;
 	}
+
+	@media screen and (min-width: 800px) {
+		// Move the navigation buttons to the bottom of the screen
+		> .navigation-buttons {
+			order: 1;
+			margin-top: auto;
+		}
+	}
+
+	// -- sub-components --
 
 	.with-text-shadow {
 		text-shadow: 0 0 3px rgba(20, 20, 20, 0.9);
@@ -56,14 +67,46 @@
 		}
 	}
 
+	.navigation-content {
+		flex-grow: 1;
+		display: flex;
+	}
+
 	.help-page-container {
+		display: flex;
+		align-items: center;
+		flex-grow: 1;
+
 		> .label {
 			@extend .with-text-shadow;
 
+			flex-grow: 1;
 			text-align: center;
 			font-size: 20pt;
 			margin-left: 15px;
 			margin-right: 15px;
+			margin-top: 0px;
+
+			&.-large-space-below {
+				margin-top: 0;
+				margin-bottom: auto;
+			}
+
+			&.-small-space-above {
+				margin-top: 40px;
+				margin-bottom: auto;
+			}
+
+			&.-large-space-above {
+				margin-top: auto;
+				margin-bottom: 10px;
+			}
+
+			transition: 0.5s ease margin-top;
+
+			@media (prefers-reduced-motion: reduce) {
+				transition: none;
+			}
 		}
 
 		> .cloned-element-container {
@@ -86,7 +129,9 @@
 		display: flex;
 		flex-direction: row;
 		justify-content: space-between;
-		margin-bottom: 25px;
+
+		// Enforce left-to-right (enforces consistency with drag)
+		direction: ltr;
 
 		> button:disabled {
 			opacity: 0.5;
@@ -102,12 +147,19 @@
 			}
 		}
 
-		&.-has-next > .next {
-			font-size: 1.4em;
-		}
+		> .next:not(:disabled) {
+			@keyframes highlight-button {
+				0% { transform: scale(1); }
+				50% { transform: scale(1.2); }
+				55% { transform: scale(1.2) rotate(2deg); }
+				65% { transform: scale(1.2) rotate(-2deg); }
+				100% { transform: scale(1); }
+			}
+			animation: 0.5s ease highlight-button 0.5s;
 
-		&.-has-previous > .previous {
-			font-size: 1.4em;
+			@media (prefers-reduced-motion: reduce) {
+				animation: none;
+			}
 		}
 
 		> .next::after {
@@ -118,6 +170,19 @@
 		> .previous::before {
 			content: "❮";
 			margin-right: 3px;
+		}
+
+		&.-has-next > .next {
+			font-size: 1.4em;
+		}
+
+		&.-has-previous > .previous {
+			font-size: 1.4em;
+		}
+
+		&.-highlight-next > .next, &.-highlight-previous > .previous {
+			font-weight: bold;
+			font-size: 1.4em;
 		}
 	}
 }

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -200,7 +200,7 @@
 			}
 		}
 
-		> .next:not(:disabled) {
+		&:not(.-has-previous) > .next:not(:disabled) {
 			@keyframes highlight-button {
 				0% { transform: scale(1); }
 				50% { transform: scale(1.2); }
@@ -235,6 +235,7 @@
 
 		&.-highlight-next > .next, &.-highlight-previous > .previous {
 			font-weight: bold;
+			background-color: rgba(200, 200, 200, 0.1);
 			font-size: 1.4em;
 		}
 	}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -2,6 +2,8 @@
 .toolbar-help-overlay {
 	width: 100%;
 	height: 100%;
+	max-width: none;
+	max-height: none;
 	border: none;
 	margin: 0;
 	padding: 0;
@@ -11,10 +13,15 @@
 	// TODO: Use theme colors
 	color: white;
 	--icon-color: white;
-	background-color: rgba(0, 0, 0, 0.8);
 
-	backdrop-filter: blur(1px);
-	-webkit-backdrop-filter: blur(1px);
+	background-color: transparent;
+
+	&::backdrop {
+		background-color: rgba(0, 0, 0, 0.8);
+
+		backdrop-filter: blur(1px);
+		-webkit-backdrop-filter: blur(1px);
+	}
 
 	display: flex;
 	flex-direction: column;

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -9,6 +9,7 @@
 	padding: 0;
 	z-index: 5;
 	touch-action: none;
+	overflow: hidden;
 
 	// TODO: Use theme colors
 	color: white;
@@ -128,16 +129,16 @@
 				margin: 0;
 			}
 
+			* {
+				pointer-events: none !important;
+			}
+
 			&:not(.-clickable) * {
 				cursor: unset !important;
 			}
 
 			&.-clickable {
 				cursor: pointer;
-
-				* {
-					pointer-events: none !important;
-				}
 
 				z-index: 2;
 				touch-action: none;
@@ -215,20 +216,25 @@
 }
 
 
-.toolbar-element .help-button {
-	float: right;
-	border: 1px solid var(--icon-color);
-	color: var(--icon-color);
-	background-color: var(--background-color-1);
+.toolbar-element .toolbar-help-overlay-button {
+	height: 0;
+	position: relative;
 
-	margin: 15px;
-	margin-top: 0;
+	> .button {
+		position: absolute;
+		right: 0;
+		margin: 15px;
+		margin-top: 0;
 
-	border-radius: 100%;
-	width: 1.2em;
-	height: 1.2em;
-	padding: 0;
+		border: 1px solid var(--icon-color);
+		color: var(--icon-color);
 
-	text-align: center;
-	opacity: 0.5;
+		border-radius: 100%;
+		width: 1.2em;
+		height: 1.2em;
+		padding: 0;
+
+		text-align: center;
+		opacity: 0.5;
+	}
 }

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -120,6 +120,8 @@
 			position: absolute;
 			z-index: -1;
 
+			border-radius: 10px;
+			background-color: var(--background-color-1);
 			box-shadow: 0 0 3px rgba(100, 100, 100, 0.5);
 			
 			> * {
@@ -131,17 +133,22 @@
 			}
 
 			&.-clickable {
-				&, * {
-					cursor: pointer !important;
+				cursor: pointer;
+
+				* {
+					pointer-events: none !important;
 				}
 
 				z-index: 2;
+				touch-action: none;
 			}
 
-			opacity: 0.001;
+			filter: opacity(0);
 			&.-active {
-				opacity: 1;
+				filter: opacity(1);
 			}
+
+			transition: 0.1s ease opacity;
 		}
 	}
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -251,7 +251,6 @@
 	// Use flex so that items reverse in RTL
 	display: flex;
 	justify-content: end;
-	align-items: last baseline;
 
 	> .button {
 		margin: 4px;

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -134,7 +134,7 @@
 
 			> * {
 				margin: 0;
-				opacity: 0.01;
+				opacity: 0.01 !important;
 				transition: 0.3s ease opacity !important;
 			}
 
@@ -154,11 +154,6 @@
 
 				&.has-long-press-or-hover {
 					opacity: 0.5 !important;
-
-					> * {
-						opacity: 0.01 !important;
-						transition: 0s ease opacity !important;
-					}
 				}
 			}
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -12,14 +12,17 @@
 	overflow: hidden;
 
 	// TODO: Use theme colors
-	color: white;
-	--icon-color: white;
+	$help-overlay-foreground: white;
+	$help-overlay-background: rgba(0, 0, 0, 0.8);
+
+	color: $help-overlay-foreground;
+	--icon-color: #{$help-overlay-foreground};
 
 	// We use ::backdrop for background styling
 	background-color: transparent;
 
 	&::backdrop {
-		background-color: rgba(0, 0, 0, 0.8);
+		background-color: $help-overlay-background;
 
 		backdrop-filter: blur(1px);
 		-webkit-backdrop-filter: blur(1px);
@@ -85,7 +88,7 @@
 
 		background: transparent;
 		border: none;
-		color: white;
+		color: var(--help-overlay-foreground);
 
 		border-radius: 15px;
 	}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -241,6 +241,11 @@
 			font-size: 1.4em;
 		}
 	}
+
+	.navigation-help {
+		margin-top: 1em;
+		font-size: 0.7em;	
+	}
 }
 
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.scss
@@ -126,8 +126,21 @@
 				margin: 0;
 			}
 
-			* {
+			&:not(.-clickable) * {
 				cursor: unset !important;
+			}
+
+			&.-clickable {
+				&, * {
+					cursor: pointer !important;
+				}
+
+				z-index: 2;
+			}
+
+			opacity: 0.001;
+			&.-active {
+				opacity: 1;
 			}
 		}
 	}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.test.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.test.ts
@@ -1,0 +1,143 @@
+import { Vec2 } from '@js-draw/math';
+import createEditor from '../../testing/createEditor';
+import { ToolbarContext } from '../types';
+import HelpDisplay from './HelpDisplay';
+import sendHtmlSwipe from '../../testing/sendHtmlSwipe';
+
+const createOverlay = (element: HTMLElement) => {
+	document.body.appendChild(element);
+};
+
+const makeContext = (): ToolbarContext => {
+	return createEditor();
+};
+
+const createTestHelpDisplay = (testHelpTexts: string[]) => {
+	const display = new HelpDisplay(createOverlay, makeContext());
+
+	let elementCounter = 0;
+	for (const helpText of testHelpTexts) {
+		elementCounter++;
+
+		const testElement = document.createElement('button');
+		testElement.innerText = `Test element ${elementCounter}`;
+		testElement.classList.add(`test-element-${elementCounter}`);
+
+		display.registerTextHelpForElement(testElement, helpText);
+	}
+
+	// Show now so that related elements can be returned.
+	display.showHelpOverlay();
+
+	const overlayElementMatches = document.querySelectorAll<HTMLElement>('.toolbar-help-overlay');
+	expect(overlayElementMatches).toHaveLength(1);
+	const helpOverlay = overlayElementMatches[0];
+
+	const nextButton = helpOverlay.querySelector<HTMLButtonElement>('.navigation-buttons > button.next')!;
+	expect(nextButton).not.toBeFalsy();
+
+	const previousButton = helpOverlay.querySelector<HTMLButtonElement>('.navigation-buttons > button.previous')!;
+	expect(previousButton).not.toBeFalsy();
+
+	const closeButton = helpOverlay.querySelector<HTMLButtonElement>('.close-button')!;
+	expect(closeButton).not.toBeFalsy();
+
+	return {
+		display,
+		helpOverlay,
+		nextButton,
+		previousButton,
+		closeButton,
+
+		// The label may be re-created, so we re-query it each time it's needed.
+		getLabel: () => {
+			const labelMatches = helpOverlay.querySelectorAll('.help-page-container .current-item-help');
+			expect(labelMatches).toHaveLength(1);
+			return labelMatches[0] as HTMLElement;
+		},
+	};
+};
+
+describe('HelpDisplay', () => {
+	afterEach(() => {
+		// Clean up any open dialogs, etc.
+		document.body.replaceChildren();
+	});
+
+	test('should show help registered for just the current element', async () => {
+		const { helpOverlay, getLabel, closeButton, nextButton, previousButton } = createTestHelpDisplay(
+			[ 'Help text here...', 'Help text 2' ]
+		);
+
+		// Should show the help text for the first item
+		expect(getLabel().innerText).toMatch('Help text here...');
+
+		// Clicking "next" should move to the next item
+		nextButton.click();
+
+		// Should now have the help text for the second element
+		expect(getLabel().innerText).toBe('Help text 2');
+
+		nextButton.click();
+
+		// Should still just have the help text for the second element
+		expect(getLabel().innerText).toBe('Help text 2');
+
+		// May have additional instructions (so just match the start)
+		previousButton.click();
+		expect(getLabel().innerText).toBe('Help text here...');
+
+		// Should stay on the first
+		previousButton.click();
+		expect(getLabel().innerText).toBe('Help text here...');
+
+		// Should still be in the document
+		expect(helpOverlay.parentElement).not.toBeFalsy();
+
+		// Should close when clicking close
+		closeButton.click();
+
+		// Wait for animations
+		await jest.advanceTimersByTimeAsync(500);
+		expect(helpOverlay.parentElement).toBeFalsy();
+	});
+
+	test('dragging the dialog background should transition between items', async () => {
+		const { helpOverlay, getLabel } = createTestHelpDisplay(
+			[ 'Item 1', 'Item 2', 'Item 3' ]
+		);
+
+		expect(getLabel().innerText).toBe('Item 1');
+
+		// Swipe from right to left
+		await sendHtmlSwipe(helpOverlay, Vec2.of(50, 50), Vec2.of(0, 50));
+		expect(getLabel().innerText).toBe('Item 2');
+
+		// Swipe to the first again
+		await sendHtmlSwipe(helpOverlay, Vec2.of(50, 50), Vec2.of(100, 60));
+		expect(getLabel().innerText).toBe('Item 1');
+
+		// Shouldn't be possible to swipe before the first item
+		await sendHtmlSwipe(helpOverlay, Vec2.of(50, 50), Vec2.of(1000, 60));
+		expect(getLabel().innerText).toBe('Item 1');
+
+		await sendHtmlSwipe(helpOverlay, Vec2.of(150, 50), Vec2.of(100, 30));
+		expect(getLabel().innerText).toBe('Item 2');
+
+		// Small swipes should do nothing
+		await sendHtmlSwipe(helpOverlay, Vec2.of(50, 50), Vec2.of(35, 50));
+		expect(getLabel().innerText).toBe('Item 2');
+
+		// Swipes should work even with a large vertical component
+		await sendHtmlSwipe(helpOverlay, Vec2.of(150, 50), Vec2.of(10, 0));
+		expect(getLabel().innerText).toBe('Item 3');
+
+		// Should not be possible to swipe past the last item.
+		await sendHtmlSwipe(helpOverlay, Vec2.of(150, 50), Vec2.of(10, 100));
+		expect(getLabel().innerText).toBe('Item 3');
+
+		// Should be possible to swipe back
+		await sendHtmlSwipe(helpOverlay, Vec2.of(50, 50), Vec2.of(100, 60));
+		expect(getLabel().innerText).toBe('Item 2');
+	});
+});

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -1,0 +1,265 @@
+import { Rect2, Vec2 } from '@js-draw/math';
+import { ToolbarContext } from '../types';
+import makeDraggable from './makeDraggable';
+import { MutableReactiveValue } from '../../util/ReactiveValue';
+
+interface HelpRecord {
+	targetElement: HTMLElement;
+	helpText: string;
+}
+
+const cloneElementWithStyles = (element: HTMLElement) => {
+	const restyle = (originalElement: HTMLElement, clonedElement: HTMLElement) => {
+		const originalComputedStyle = getComputedStyle(originalElement);
+
+		for (const propertyName of originalComputedStyle) {
+			const propertyValue = originalComputedStyle.getPropertyValue(propertyName);
+			clonedElement.style.setProperty(propertyName, propertyValue);
+		}
+
+		for (let i = 0; i < originalElement.children.length; i++) {
+			const originalChild = originalElement.children.item(i) as HTMLElement;
+			const clonedChild = clonedElement.children.item(i) as HTMLElement;
+
+			if (originalChild && clonedChild) {
+				restyle(originalChild, clonedChild);
+			} else {
+				console.warn('Missing child');
+			}
+		}
+	};
+
+	const elementClone = element.cloneNode(true) as HTMLElement;
+	restyle(element, elementClone);
+	return elementClone;
+};
+
+const createHelpPage = (item: HelpRecord) => {
+	const container = document.createElement('div');
+	container.classList.add('help-page-container');
+
+	const textLabel = document.createElement('div');
+	textLabel.classList.add('label');
+	textLabel.innerText = item.helpText;
+
+	const refreshContent = () => {
+		const targetBBox = Rect2.of(item.targetElement.getBoundingClientRect());
+		const clonedElementContainer = document.createElement('div');
+
+		const clonedElement = cloneElementWithStyles(item.targetElement);
+		clonedElement.style.margin = '0';
+
+		clonedElementContainer.classList.add('cloned-element-container');
+		clonedElementContainer.style.position = 'absolute';
+		clonedElementContainer.style.left = `${targetBBox.topLeft.x}px`;
+		clonedElementContainer.style.top = `${targetBBox.topLeft.y}px`;
+		clonedElementContainer.style.backgroundColor = 'var(--background-color-1)';
+		clonedElementContainer.style.borderRadius = '10px';
+
+		clonedElementContainer.appendChild(clonedElement);
+		container.replaceChildren(clonedElementContainer, textLabel);
+	};
+
+	return {
+		addToParent: (parent: HTMLElement) => {
+			refreshContent();
+			parent.appendChild(container);
+		},
+		refresh: refreshContent,
+	};
+};
+
+export default class HelpDisplay {
+	#helpData: HelpRecord[] = [];
+
+	public constructor(
+		private createOverlay: (htmlElement: HTMLElement)=>void,
+		private context: ToolbarContext,
+	) {
+	}
+
+	private showHelpOverlay() {
+		const overlay = document.createElement('dialog');
+		overlay.classList.add('toolbar-help-overlay');
+
+		const makeCloseButton = () => {
+			const closeButton = document.createElement('button');
+			closeButton.classList.add('close-button');
+			closeButton.appendChild(this.context.icons.makeCloseIcon());
+
+			const label = this.context.localization.close;
+			closeButton.setAttribute('aria-label', label);
+			closeButton.setAttribute('title', label);
+
+			closeButton.onclick = () => { overlay.close(); };
+
+			return closeButton;
+		};
+
+		const makeNavigationContent = () => {
+			const helpPages = this.#helpData.map(item => createHelpPage(item));
+			const currentPage = MutableReactiveValue.fromInitialValue(0);
+
+			const content = document.createElement('div');
+
+			const showPage = (pageIndex: number) => {
+				if (pageIndex >= this.#helpData.length || pageIndex < 0) {
+					content.replaceChildren();
+					return;
+				}
+
+				content.replaceChildren();
+				helpPages[pageIndex].addToParent(content);
+			};
+			currentPage.onUpdateAndNow(showPage);
+
+			const navigationControl = {
+				content,
+				currentPage,
+
+				toNext: () => {
+					if (navigationControl.hasNext()) {
+						currentPage.set(currentPage.get() + 1);
+					}
+				},
+				toPrevious: () => {
+					if (navigationControl.hasPrevious()) {
+						currentPage.set(currentPage.get() - 1);
+					}
+				},
+				hasNext: () => {
+					return currentPage.get() + 1 < helpPages.length;
+				},
+				hasPrevious: () => {
+					return currentPage.get() > 0;
+				},
+				refreshCurrent: () => {
+					showPage(currentPage.get());
+				},
+			};
+			return navigationControl;
+		};
+
+		const makeNavigationButtons = (navigation: ReturnType<typeof makeNavigationContent>) => {
+			const navigationButtonContainer = document.createElement('div');
+			navigationButtonContainer.classList.add('navigation-buttons');
+
+			const nextButton = document.createElement('button');
+			const previousButton = document.createElement('button');
+
+			nextButton.innerText = this.context.localization.next;
+			previousButton.innerText = this.context.localization.previous;
+
+			nextButton.classList.add('next');
+			previousButton.classList.add('previous');
+
+			const updateButtonVisibility = () => {
+				navigationButtonContainer.classList.remove('-has-next', '-has-previous');
+
+				if (navigation.hasNext()) {
+					navigationButtonContainer.classList.add('-has-next');
+					nextButton.disabled = false;
+				} else {
+					navigationButtonContainer.classList.remove('-has-next');
+					nextButton.disabled = true;
+				}
+
+				if (navigation.hasPrevious()) {
+					navigationButtonContainer.classList.add('-has-previous');
+					previousButton.disabled = false;
+				} else {
+					navigationButtonContainer.classList.remove('-has-previous');
+					previousButton.disabled = true;
+				}
+			};
+			navigation.currentPage.onUpdateAndNow(updateButtonVisibility);
+
+			nextButton.onclick = () => {
+				navigation.toNext();
+			};
+
+			previousButton.onclick = () => {
+				navigation.toPrevious();
+			};
+
+			navigationButtonContainer.replaceChildren(previousButton, nextButton);
+
+			return navigationButtonContainer;
+		};
+
+		const navigation = makeNavigationContent();
+		const navigationButtons = makeNavigationButtons(navigation);
+
+		overlay.replaceChildren(
+			makeCloseButton(),
+			navigationButtons,
+			navigation.content,
+		);
+
+		this.createOverlay(overlay);
+		overlay.show();
+
+		const setDragOffset = (offset: number) => {
+			if (offset > 0 && !navigation.hasPrevious()) {
+				offset = 0;
+			}
+
+			if (offset < 0 && !navigation.hasNext()) {
+				offset = 0;
+			}
+
+			overlay.style.transform = `translate(${offset}px, 0px)`;
+		};
+
+		const dragListener = makeDraggable(overlay, {
+			draggableChildElements: [ navigation.content ],
+			onDrag: (_deltaX: number, _deltaY: number, totalDisplacement: Vec2) => {
+				overlay.classList.add('-dragging');
+				setDragOffset(totalDisplacement.x);
+			},
+			onDragEnd: (dragStatistics) => {
+				overlay.classList.remove('-dragging');
+				setDragOffset(0);
+
+				if (!dragStatistics.roughlyClick) {
+					if (dragStatistics.displacement.x > 0) {
+						navigation.toPrevious();
+					} else {
+						navigation.toNext();
+					}
+				}
+			},
+		});
+
+		let resizeObserver: ResizeObserver|null;
+		if (window.ResizeObserver) {
+			resizeObserver = new ResizeObserver(() => {
+				navigation.refreshCurrent();
+			});
+			resizeObserver.observe(overlay);
+		}
+
+		overlay.addEventListener('close', () => {
+			dragListener.removeListeners();
+			overlay.remove();
+			resizeObserver?.disconnect();
+		});
+	}
+
+	public registerTextHelpForElement(targetElement: HTMLElement, helpText: string) {
+		this.#helpData.push({ targetElement, helpText });
+	}
+
+	public createToggleButton(): HTMLButtonElement {
+		const helpButton = document.createElement('button');
+		helpButton.classList.add('help-button');
+		helpButton.innerText = '?';
+		helpButton.setAttribute('aria-label', this.context.localization.help);
+
+		helpButton.onclick = () => {
+			this.showHelpOverlay();
+		};
+
+		return helpButton;
+	}
+}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -29,10 +29,11 @@ const createHelpPage = (item: HelpRecord) => {
 		const combinedBBox = getCombinedBBox();
 
 		if (labelBBox.intersects(combinedBBox)) {
+			const containerBBox = Rect2.of(container.getBoundingClientRect());
 			const spaceAboveCombined = combinedBBox.topLeft.y;
-			const spaceBelowCombined = combinedBBox.bottomLeft.y;
+			const spaceBelowCombined = containerBBox.bottomLeft.y - combinedBBox.bottomLeft.y;
 
-			if (spaceAboveCombined > spaceBelowCombined && spaceAboveCombined > labelBBox.height / 2) {
+			if (spaceAboveCombined > spaceBelowCombined && spaceAboveCombined > labelBBox.height / 3) {
 				// Push to the very top
 				textLabel.classList.remove('-small-space-above', '-large-space-above');
 				textLabel.classList.add('-large-space-below');

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -198,7 +198,13 @@ export default class HelpDisplay {
 		overlay.setAttribute('autofocus', 'true');
 		overlay.classList.add('toolbar-help-overlay');
 
-		const onBackgroundClick = () => { overlay.close(); };
+		let lastDragTimestamp = 0;
+		const onBackgroundClick = () => {
+			const wasJustDragging = performance.now() - lastDragTimestamp < 100;
+			if (!wasJustDragging) {
+				overlay.close();
+			}
+		};
 
 		const makeCloseButton = () => {
 			const closeButton = document.createElement('button');
@@ -358,7 +364,6 @@ export default class HelpDisplay {
 
 
 		// Listeners
-
 		const dragListener = makeDraggable(overlay, {
 			draggableChildElements: [ navigation.content ],
 			onDrag: (_deltaX: number, _deltaY: number, totalDisplacement: Vec2) => {
@@ -377,6 +382,8 @@ export default class HelpDisplay {
 					} else if (xDisplacement < -minDragOffsetToTransition) {
 						navigation.toNext();
 					}
+
+					lastDragTimestamp = dragStatistics.endTimestamp;
 				}
 			},
 		});

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -37,7 +37,9 @@ const createHelpPage = (
 	//       HelpItem 1                   HelpItem 2     HelpItem 3
 	// if the first help item had two elements (and thus two cloned element containers).
 	//
-	let clonedElementContainers: HTMLElement[][] = [];
+	// We also store the original bounding box -- the bounding box of the clones can change
+	// while dragging to switch pages.
+	let clonedElementContainers: { container: HTMLElement, bbox: Rect2 }[][] = [];
 
 	// Clicking on the background of the help area should send an event (e.g. to allow the
 	// help container to be closed).
@@ -66,9 +68,7 @@ const createHelpPage = (
 	const updateClonedElementStates = () => {
 		const currentItemBBox = getCombinedBBox();
 		for (let index = 0; index < clonedElementContainers.length; index++) {
-			for (const container of clonedElementContainers[index]) {
-				const containerBBox = Rect2.of(container.getBoundingClientRect());
-
+			for (const { container, bbox: containerBBox } of clonedElementContainers[index]) {
 				if (index === currentItemIndex) {
 					container.classList.add('-active');
 					container.classList.remove('-clickable', '-background');
@@ -151,7 +151,7 @@ const createHelpPage = (
 
 				addLongPressOrHoverCssClasses(clonedElementContainer, { timeout: 0 });
 
-				itemCloneContainers.push(clonedElementContainer);
+				itemCloneContainers.push({ container: clonedElementContainer, bbox: targetBBox });
 				container.appendChild(clonedElementContainer);
 			}
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -345,17 +345,32 @@ export default class HelpDisplay {
 		});
 	}
 
+	/** Marks `helpText` as associated with a single `targetElement`. */
 	public registerTextHelpForElement(targetElement: HTMLElement, helpText: string) {
 		this.registerTextHelpForElements([ targetElement ], helpText);
 	}
 
+	/** Marks `helpText` as associated with all elements in `targetElements`. */
 	public registerTextHelpForElements(targetElements: HTMLElement[], helpText: string) {
 		this.#helpData.push({ targetElements: [ ...targetElements ], helpText });
 	}
 
-	public createToggleButton(): HTMLButtonElement {
+	/** Returns true if any help text has been registered. */
+	public hasHelpText() {
+		return this.#helpData.length > 0;
+	}
+
+	/**
+	 * Creates and returns a button that toggles the help display.
+	 *
+	 * @internal
+	 */
+	public createToggleButton(): HTMLElement {
+		const buttonContainer = document.createElement('div');
+		buttonContainer.classList.add('toolbar-help-overlay-button');
+
 		const helpButton = document.createElement('button');
-		helpButton.classList.add('help-button');
+		helpButton.classList.add('button');
 		helpButton.innerText = '?';
 		helpButton.setAttribute('aria-label', this.context.localization.help);
 
@@ -363,6 +378,8 @@ export default class HelpDisplay {
 			this.showHelpOverlay();
 		};
 
-		return helpButton;
+		buttonContainer.appendChild(helpButton);
+
+		return buttonContainer;
 	}
 }

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -24,12 +24,13 @@ const createHelpPage = (item: HelpRecord) => {
 		return Rect2.union(...itemBoundingBoxes);
 	};
 
-	const refreshLabelPosition = () => {
+	const updateLabelPosition = () => {
 		const labelBBox = Rect2.of(textLabel.getBoundingClientRect());
 		const combinedBBox = getCombinedBBox();
 
 		if (labelBBox.intersects(combinedBBox)) {
 			const containerBBox = Rect2.of(container.getBoundingClientRect());
+
 			const spaceAboveCombined = combinedBBox.topLeft.y;
 			const spaceBelowCombined = containerBBox.bottomLeft.y - combinedBBox.bottomLeft.y;
 
@@ -86,11 +87,11 @@ const createHelpPage = (item: HelpRecord) => {
 		addToParent: (parent: HTMLElement) => {
 			refreshContent();
 			parent.appendChild(container);
-			refreshLabelPosition();
+			updateLabelPosition();
 		},
 		refresh: () => {
 			refreshContent();
-			refreshLabelPosition();
+			updateLabelPosition();
 		},
 	};
 };
@@ -224,7 +225,7 @@ export default class HelpDisplay {
 		);
 
 		this.createOverlay(overlay);
-		overlay.show();
+		overlay.showModal();
 
 		const minDragOffsetToTransition = 30;
 		const setDragOffset = (offset: number) => {

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -21,6 +21,7 @@ const createHelpPage = (
 
 	const textLabel = document.createElement('div');
 	textLabel.classList.add('label', '-space-above');
+	textLabel.setAttribute('aria-live', 'polite');
 
 	// The current active item in helpItems.
 	// (Only one item is active at a time, but each item can have multiple HTMLElements).
@@ -73,7 +74,6 @@ const createHelpPage = (
 				if (index === currentItemIndex) {
 					container.classList.add('-active');
 					container.classList.remove('-clickable', '-background');
-					container.removeAttribute('aria-hidden');
 					container.onclick = () => {};
 				}
 				// Otherwise, if not containing the current element
@@ -85,7 +85,6 @@ const createHelpPage = (
 						container.classList.add('-background');
 						container.classList.remove('-active', '-clickable');
 					}
-					container.setAttribute('aria-hidden', 'true');
 
 					const containerIndex = index;
 					container.onclick = () => {
@@ -123,6 +122,11 @@ const createHelpPage = (
 
 	const refreshContent = () => {
 		container.replaceChildren();
+
+		// Add the text label first so that screen readers will visit it first.
+		textLabel.classList.remove('-large-space-above');
+		textLabel.classList.add('-small-space-above', '-large-space-below');
+		container.appendChild(textLabel);
 
 		const screenBBox = new Rect2(0, 0, window.innerWidth, window.innerHeight);
 
@@ -171,10 +175,6 @@ const createHelpPage = (
 		}
 
 		updateClonedElementStates();
-
-		textLabel.classList.remove('-large-space-above');
-		textLabel.classList.add('-small-space-above', '-large-space-below');
-		container.appendChild(textLabel);
 	};
 
 	const refresh = () => {
@@ -455,7 +455,16 @@ export default class HelpDisplay {
 			}
 		};
 
+		overlay.onkeyup = event => {
+			if (event.code === 'Escape') {
+				closeOverlay();
+				event.preventDefault();
+			}
+		};
+
 		overlay.addEventListener('close', () => {
+			this.context.announceForAccessibility(this.context.localization.helpHidden);
+
 			mediaQueryList.removeEventListener('change', onMediaChangeListener);
 			dragListener.removeListeners();
 			resizeObserver?.disconnect();

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -460,6 +460,14 @@ export default class HelpDisplay {
 				closeOverlay();
 				event.preventDefault();
 			}
+			else if (event.code === 'ArrowRight') {
+				navigation.toNext();
+				event.preventDefault();
+			}
+			else if (event.code === 'ArrowLeft') {
+				navigation.toPrevious();
+				event.preventDefault();
+			}
 		};
 
 		overlay.addEventListener('close', () => {

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -371,7 +371,11 @@ export default class HelpDisplay {
 
 		const helpButton = document.createElement('button');
 		helpButton.classList.add('button');
-		helpButton.innerText = '?';
+
+		const icon = this.context.icons.makeHelpIcon();
+		icon.classList.add('icon');
+		helpButton.appendChild(icon);
+
 		helpButton.setAttribute('aria-label', this.context.localization.help);
 
 		helpButton.onclick = () => {

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -77,20 +77,20 @@ const createHelpPage = (
 					container.onclick = () => {};
 				}
 				// Otherwise, if not containing the current element
-				else if (!containerBBox.containsRect(currentItemBBox)) {
-					container.classList.add('-clickable');
-					container.classList.remove('-active', '-background');
+				else {
+					if (!containerBBox.containsRect(currentItemBBox)) {
+						container.classList.add('-clickable');
+						container.classList.remove('-active', '-background');
+					} else {
+						container.classList.add('-background');
+						container.classList.remove('-active', '-clickable');
+					}
 					container.setAttribute('aria-hidden', 'true');
 
 					const containerIndex = index;
 					container.onclick = () => {
 						onItemClick(containerIndex);
 					};
-				} else {
-					container.classList.add('-background');
-					container.classList.remove('-active', '-clickable');
-					container.setAttribute('aria-hidden', 'true');
-					container.onclick = () => {};
 				}
 			}
 		}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -123,13 +123,22 @@ const createHelpPage = (
 	const refreshContent = () => {
 		container.replaceChildren();
 
+		const screenBBox = new Rect2(0, 0, window.innerWidth, window.innerHeight);
+
 		clonedElementContainers = [];
 		for (let itemIndex = 0; itemIndex < helpItems.length; itemIndex++) {
 			const item = helpItems[itemIndex];
 			const itemCloneContainers = [];
 
 			for (const targetElement of item.targetElements) {
-				const targetBBox = Rect2.of(targetElement.getBoundingClientRect());
+				let targetBBox = Rect2.of(targetElement.getBoundingClientRect());
+
+				// Move the element onto the screen if not visible
+				if (!screenBBox.containsRect(targetBBox)) {
+					const bottomCenter = screenBBox.bottomLeft.lerp(screenBBox.bottomRight, 0.5);
+					const delta = bottomCenter.minus(targetBBox.center);
+					targetBBox = targetBBox.translatedBy(delta);
+				}
 
 				const clonedElement = cloneElementWithStyles(targetElement);
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -3,6 +3,7 @@ import { ToolbarContext } from '../types';
 import makeDraggable from './makeDraggable';
 import { MutableReactiveValue } from '../../util/ReactiveValue';
 import cloneElementWithStyles from '../../util/cloneElementWithStyles';
+import addLongPressOrHoverCssClasses from '../../util/addLongPressOrHoverCssClasses';
 
 interface HelpRecord {
 	readonly targetElements: HTMLElement[];
@@ -68,22 +69,25 @@ const createHelpPage = (
 			for (const container of clonedElementContainers[index]) {
 				const containerBBox = Rect2.of(container.getBoundingClientRect());
 
-				container.classList.remove('-active', '-clickable');
-				container.setAttribute('aria-hidden', 'true');
-
 				if (index === currentItemIndex) {
 					container.classList.add('-active');
+					container.classList.remove('-clickable');
 					container.removeAttribute('aria-hidden');
 					container.onclick = () => {};
 				}
 				// Otherwise, if not containing the current element
 				else if (!containerBBox.containsRect(currentItemBBox)) {
 					container.classList.add('-clickable');
+					container.classList.remove('-active');
+					container.setAttribute('aria-hidden', 'true');
 
 					const containerIndex = index;
 					container.onclick = () => {
 						onItemClick(containerIndex);
 					};
+				} else {
+					container.classList.remove('-active', '-clickable');
+					container.setAttribute('aria-hidden', 'true');
 				}
 			}
 		}
@@ -142,6 +146,8 @@ const createHelpPage = (
 				clonedElementContainer.style.top = `${targetBBox.topLeft.y}px`;
 
 				clonedElementContainer.replaceChildren(clonedElement);
+
+				addLongPressOrHoverCssClasses(clonedElementContainer, { timeout: 0 });
 
 				itemCloneContainers.push(clonedElementContainer);
 				container.appendChild(clonedElementContainer);

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -61,6 +61,8 @@ const createHelpPage = (items: HelpRecord[], onItemClick: (itemIndex: number)=>v
 	const refreshContent = () => {
 		container.replaceChildren();
 
+		const currentBBox = getCombinedBBox();
+
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const item = items[itemIndex];
 
@@ -82,14 +84,14 @@ const createHelpPage = (items: HelpRecord[], onItemClick: (itemIndex: number)=>v
 				clonedElementContainer.style.position = 'absolute';
 				clonedElementContainer.style.left = `${targetBBox.topLeft.x}px`;
 				clonedElementContainer.style.top = `${targetBBox.topLeft.y}px`;
-				clonedElementContainer.style.backgroundColor = 'var(--background-color-1)';
-				clonedElementContainer.style.borderRadius = '10px';
 
 				clonedElementContainer.replaceChildren(clonedElement);
 
 				if (item === currentItem) {
 					clonedElementContainer.classList.add('-active');
-				} else {
+				}
+				// Otherwise, if not containing the current element
+				else if (!targetBBox.containsRect(currentBBox)) {
 					clonedElementContainer.classList.add('-clickable');
 					clonedElementContainer.setAttribute('aria-hidden', 'true');
 
@@ -139,6 +141,7 @@ export default class HelpDisplay {
 
 	private showHelpOverlay() {
 		const overlay = document.createElement('dialog');
+		overlay.setAttribute('autofocus', 'true');
 		overlay.classList.add('toolbar-help-overlay');
 
 		const makeCloseButton = () => {

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -134,9 +134,11 @@ const createHelpPage = (
 				let targetBBox = Rect2.of(targetElement.getBoundingClientRect());
 
 				// Move the element onto the screen if not visible
-				if (!screenBBox.containsRect(targetBBox)) {
-					const bottomCenter = screenBBox.bottomLeft.lerp(screenBBox.bottomRight, 0.5);
-					const delta = bottomCenter.minus(targetBBox.center);
+				if (!screenBBox.intersects(targetBBox)) {
+					const screenBottomCenter = screenBBox.bottomLeft.lerp(screenBBox.bottomRight, 0.5);
+					const targetBottomCenter = targetBBox.bottomLeft.lerp(targetBBox.bottomRight, 0.5);
+
+					const delta = screenBottomCenter.minus(targetBottomCenter);
 					targetBBox = targetBBox.translatedBy(delta);
 				}
 

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -71,14 +71,14 @@ const createHelpPage = (
 
 				if (index === currentItemIndex) {
 					container.classList.add('-active');
-					container.classList.remove('-clickable');
+					container.classList.remove('-clickable', '-background');
 					container.removeAttribute('aria-hidden');
 					container.onclick = () => {};
 				}
 				// Otherwise, if not containing the current element
 				else if (!containerBBox.containsRect(currentItemBBox)) {
 					container.classList.add('-clickable');
-					container.classList.remove('-active');
+					container.classList.remove('-active', '-background');
 					container.setAttribute('aria-hidden', 'true');
 
 					const containerIndex = index;
@@ -86,8 +86,10 @@ const createHelpPage = (
 						onItemClick(containerIndex);
 					};
 				} else {
+					container.classList.add('-background');
 					container.classList.remove('-active', '-clickable');
 					container.setAttribute('aria-hidden', 'true');
+					container.onclick = () => {};
 				}
 			}
 		}

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -228,11 +228,22 @@ export default class HelpDisplay {
 		overlay.setAttribute('autofocus', 'true');
 		overlay.classList.add('toolbar-help-overlay');
 
+		// Closes the overlay with a closing animation
+		const closing = false;
+		const closeOverlay = () => {
+			if (closing) return;
+
+			// If changing animationDelay, be sure to also update the CSS.
+			const animationDelay = 250; // ms
+			overlay.classList.add('-hiding');
+			setTimeout(() => overlay.close(), animationDelay);
+		};
+
 		let lastDragTimestamp = 0;
 		const onBackgroundClick = () => {
 			const wasJustDragging = performance.now() - lastDragTimestamp < 100;
 			if (!wasJustDragging) {
-				overlay.close();
+				closeOverlay();
 			}
 		};
 
@@ -245,7 +256,7 @@ export default class HelpDisplay {
 			closeButton.setAttribute('aria-label', label);
 			closeButton.setAttribute('title', label);
 
-			closeButton.onclick = () => { overlay.close(); };
+			closeButton.onclick = () => { closeOverlay(); };
 
 			return closeButton;
 		};

--- a/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
+++ b/packages/js-draw/src/toolbar/utils/HelpDisplay.ts
@@ -14,6 +14,7 @@ const createHelpPage = (
 	helpItems: HelpRecord[],
 	onItemClick: (itemIndex: number)=>void,
 	onBackgroundClick: ()=>void,
+	context: ToolbarContext,
 ) => {
 	const container = document.createElement('div');
 	container.classList.add('help-page-container');
@@ -182,7 +183,17 @@ const createHelpPage = (
 	};
 
 	const onItemChange = () => {
-		textLabel.innerText = currentItem?.helpText ?? '';
+		const instructionsElement = document.createElement('div');
+		instructionsElement.innerText = currentItem?.helpText ?? '';
+
+		const helpElement = document.createElement('div');
+		helpElement.innerText = context.localization.helpScreenNavigationHelp;
+		helpElement.classList.add('navigation-help');
+
+		textLabel.replaceChildren(
+			instructionsElement,
+			...(currentItemIndex === 0 ? [ helpElement ] : []),
+		);
 
 		updateClonedElementStates();
 	};
@@ -249,6 +260,7 @@ export default class HelpDisplay {
 				this.#helpData,
 				newPageIndex => currentPage.set(newPageIndex),
 				onBackgroundClick,
+				this.context,
 			);
 			helpPage.addToParent(content);
 

--- a/packages/js-draw/src/toolbar/utils/localization.ts
+++ b/packages/js-draw/src/toolbar/utils/localization.ts
@@ -2,6 +2,7 @@
 export interface ToolbarUtilsLocalization {
 	help: string;
 	helpScreenNavigationHelp: string;
+	helpHidden: string;
 	next: string;
 	previous: string;
 	close: string;
@@ -9,6 +10,7 @@ export interface ToolbarUtilsLocalization {
 
 export const defaultToolbarUtilsLocalization: ToolbarUtilsLocalization = {
 	help: 'Help',
+	helpHidden: 'Help hidden',
 	next: 'Next',
 	previous: 'Previous',
 	close: 'Close',

--- a/packages/js-draw/src/toolbar/utils/localization.ts
+++ b/packages/js-draw/src/toolbar/utils/localization.ts
@@ -1,0 +1,14 @@
+
+export interface ToolbarUtilsLocalization {
+	help: string;
+	next: string;
+	previous: string;
+	close: string;
+}
+
+export const defaultToolbarUtilsLocalization: ToolbarUtilsLocalization = {
+	help: 'Help',
+	next: 'Next',
+	previous: 'Previous',
+	close: 'Close',
+};

--- a/packages/js-draw/src/toolbar/utils/localization.ts
+++ b/packages/js-draw/src/toolbar/utils/localization.ts
@@ -1,6 +1,7 @@
 
 export interface ToolbarUtilsLocalization {
 	help: string;
+	helpScreenNavigationHelp: string;
 	next: string;
 	previous: string;
 	close: string;
@@ -11,4 +12,5 @@ export const defaultToolbarUtilsLocalization: ToolbarUtilsLocalization = {
 	next: 'Next',
 	previous: 'Previous',
 	close: 'Close',
+	helpScreenNavigationHelp: 'Click on a control for more information.',
 };

--- a/packages/js-draw/src/toolbar/utils/makeDraggable.ts
+++ b/packages/js-draw/src/toolbar/utils/makeDraggable.ts
@@ -1,3 +1,5 @@
+import { Vec2 } from '@js-draw/math';
+
 interface DragStatistics {
 	// Whether the drag was small enough that it was roughly
 	// a click event.
@@ -6,6 +8,9 @@ interface DragStatistics {
 	// Timestamp (as from performance.now) that the drag
 	// ended.
 	endTimestamp: number;
+
+	// Change in x and y position from the start of the gesture
+	displacement: Vec2;
 }
 
 interface DraggableOptions {
@@ -13,7 +18,7 @@ interface DraggableOptions {
 	// regardless of tag name
 	draggableChildElements: HTMLElement[];
 
-	onDrag(deltaX: number, deltaY: number): void;
+	onDrag(deltaX: number, deltaY: number, totalDisplacement: Vec2): void;
 	onDragEnd(dragStatistics: DragStatistics): void;
 }
 
@@ -118,6 +123,7 @@ const makeDraggable = (dragElement: HTMLElement, options: DraggableOptions): Dra
 		options.onDragEnd({
 			roughlyClick: isRoughlyClick(),
 			endTimestamp: performance.now(),
+			displacement: Vec2.of(lastX - startX, lastY - startY),
 		});
 		pointerDown = false;
 		startedDragging = false;
@@ -151,7 +157,7 @@ const makeDraggable = (dragElement: HTMLElement, options: DraggableOptions): Dra
 			Math.abs(x - startX) <= clickThreshold && Math.abs(y - startY) <= clickThreshold;
 
 		if (!isClick || startedDragging) {
-			options.onDrag(dx, dy);
+			options.onDrag(dx, dy, Vec2.of(x - startX, y - startY));
 
 			lastX = x;
 			lastY = y;

--- a/packages/js-draw/src/toolbar/widgets/ActionButtonWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/ActionButtonWidget.ts
@@ -4,6 +4,7 @@ import BaseWidget from './BaseWidget';
 
 export default class ActionButtonWidget extends BaseWidget {
 	#autoDisableInReadOnlyEditors: boolean;
+	#helpText: string|undefined = undefined;
 
 	public constructor(
 		editor: Editor,
@@ -19,6 +20,19 @@ export default class ActionButtonWidget extends BaseWidget {
 	) {
 		super(editor, id, localizationTable);
 		this.#autoDisableInReadOnlyEditors = autoDisableInReadOnlyEditors;
+	}
+
+	/**
+	 * Sets the text shown in a help overlay for this button.
+	 *
+	 * See {@link getHelpText}.
+	 */
+	public setHelpText(helpText: string) {
+		this.#helpText = helpText;
+	}
+
+	protected override getHelpText() {
+		return this.#helpText;
 	}
 
 	protected override shouldAutoDisableInReadOnlyEditor(): boolean {

--- a/packages/js-draw/src/toolbar/widgets/HandToolWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/HandToolWidget.ts
@@ -11,7 +11,7 @@ import BaseWidget, { SavedToolbuttonState } from './BaseWidget';
 import makeSeparator from './components/makeSeparator';
 import HelpDisplay from '../utils/HelpDisplay';
 
-const makeZoomControl = (localizationTable: ToolbarLocalization, editor: Editor) => {
+const makeZoomControl = (localizationTable: ToolbarLocalization, editor: Editor, helpDisplay?: HelpDisplay) => {
 	const zoomLevelRow = document.createElement('div');
 
 	const increaseButton = document.createElement('button');
@@ -72,6 +72,11 @@ const makeZoomControl = (localizationTable: ToolbarLocalization, editor: Editor)
 			editor.viewport.canvasToScreenTransform.inverse()
 		), addToHistory);
 	};
+
+	helpDisplay?.registerTextHelpForElement(increaseButton, localizationTable.handDropdown__zoomInHelpText);
+	helpDisplay?.registerTextHelpForElement(decreaseButton, localizationTable.handDropdown__zoomOutHelpText);
+	helpDisplay?.registerTextHelpForElement(resetViewButton, localizationTable.handDropdown__resetViewHelpText);
+	helpDisplay?.registerTextHelpForElement(zoomLevelDisplay, localizationTable.handDropdown__zoomDisplayHelpText);
 
 	return zoomLevelRow;
 };
@@ -242,11 +247,9 @@ export default class HandToolWidget extends BaseToolWidget {
 
 		makeSeparator().addTo(nonbuttonActionContainer);
 
-		const zoomControl = makeZoomControl(this.localizationTable, this.editor);
+		const zoomControl = makeZoomControl(this.localizationTable, this.editor, helpDisplay);
 		nonbuttonActionContainer.appendChild(zoomControl);
 		dropdown.appendChild(nonbuttonActionContainer);
-
-		helpDisplay?.registerTextHelpForElement(zoomControl, this.localizationTable.handDropdown__zoomHelpText);
 
 		return true;
 	}

--- a/packages/js-draw/src/toolbar/widgets/HandToolWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/HandToolWidget.ts
@@ -9,6 +9,7 @@ import { ToolbarLocalization } from '../localization';
 import BaseToolWidget from './BaseToolWidget';
 import BaseWidget, { SavedToolbuttonState } from './BaseWidget';
 import makeSeparator from './components/makeSeparator';
+import HelpDisplay from '../utils/HelpDisplay';
 
 const makeZoomControl = (localizationTable: ToolbarLocalization, editor: Editor) => {
 	const zoomLevelRow = document.createElement('div');
@@ -79,8 +80,11 @@ class HandModeWidget extends BaseWidget {
 	public constructor(
 		editor: Editor,
 
-		protected tool: PanZoom, protected flag: PanZoomMode, protected makeIcon: ()=> Element,
+		protected tool: PanZoom,
+		protected flag: PanZoomMode,
+		protected makeIcon: ()=> Element,
 		private title: string,
+		private helpText: string,
 
 		localizationTable?: ToolbarLocalization,
 	) {
@@ -121,6 +125,10 @@ class HandModeWidget extends BaseWidget {
 
 	protected override fillDropdown(_dropdown: HTMLElement): boolean {
 		return false;
+	}
+
+	protected override getHelpText() {
+		return this.helpText;
 	}
 }
 
@@ -168,6 +176,7 @@ export default class HandToolWidget extends BaseToolWidget {
 			() => this.editor.icons.makeTouchPanningIcon(),
 
 			localizationTable.touchPanning,
+			localizationTable.handDropdown__touchPanningHelpText,
 
 			localizationTable,
 		);
@@ -179,6 +188,8 @@ export default class HandToolWidget extends BaseToolWidget {
 			() => this.editor.icons.makeRotationLockIcon(),
 
 			localizationTable.lockRotation,
+			localizationTable.handDropdown__lockRotationHelpText,
+
 			localizationTable,
 		);
 
@@ -218,18 +229,24 @@ export default class HandToolWidget extends BaseToolWidget {
 		}
 	}
 
-	protected override fillDropdown(dropdown: HTMLElement): boolean {
-		super.fillDropdown(dropdown);
+	protected override getHelpText(): string {
+		return this.localizationTable.handDropdown__baseHelpText;
+	}
+
+	protected override fillDropdown(dropdown: HTMLElement, helpDisplay?: HelpDisplay): boolean {
+		super.fillDropdown(dropdown, helpDisplay);
 
 		// The container for all actions that come after the toolbar buttons.
 		const nonbuttonActionContainer = document.createElement('div');
 		nonbuttonActionContainer.classList.add(`${toolbarCSSPrefix}nonbutton-controls-main-list`);
 
 		makeSeparator().addTo(nonbuttonActionContainer);
-		nonbuttonActionContainer.appendChild(
-			makeZoomControl(this.localizationTable, this.editor)
-		);
+
+		const zoomControl = makeZoomControl(this.localizationTable, this.editor);
+		nonbuttonActionContainer.appendChild(zoomControl);
 		dropdown.appendChild(nonbuttonActionContainer);
+
+		helpDisplay?.registerTextHelpForElement(zoomControl, this.localizationTable.handDropdown__zoomHelpText);
 
 		return true;
 	}

--- a/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
@@ -304,7 +304,7 @@ export default class PenToolWidget extends BaseToolWidget {
 			this.editor,
 		);
 		helpOverlay.registerTextHelpForElement(
-			dropdown, [this.getTitle(), this.localizationTable.penDropdown__baseHelpText].join('\n')
+			dropdown, [this.getTitle(), this.localizationTable.penDropdown__baseHelpText].join('\n\n')
 		);
 
 		// Thickness: Value of the input is squared to allow for finer control/larger values.

--- a/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
@@ -310,11 +310,10 @@ export default class PenToolWidget extends BaseToolWidget {
 
 		const colorRow = document.createElement('div');
 		const colorLabel = document.createElement('label');
-		const {
-			input: colorInput, container: colorInputContainer, setValue: setColorInputValue
-		} = makeColorInput(this.editor, color => {
+		const colorInputControl = makeColorInput(this.editor, color => {
 			this.tool.setColor(color);
 		});
+		const { input: colorInput, container: colorInputContainer } = colorInputControl;
 
 		colorInput.id = `${toolbarCSSPrefix}colorInput${PenToolWidget.idCounter++}`;
 		colorLabel.innerText = this.localizationTable.colorLabel;
@@ -334,13 +333,18 @@ export default class PenToolWidget extends BaseToolWidget {
 			colorRow,
 			this.localizationTable.penDropdown__colorHelpText
 		);
+
+		if (helpDisplay) {
+			colorInputControl.registerWithHelpTextDisplay(helpDisplay);
+		}
+
 		helpDisplay?.registerTextHelpForElement(
 			thicknessRow, this.localizationTable.penDropdown__thicknessHelpText,
 		);
 
 
 		this.updateInputs = () => {
-			setColorInputValue(this.tool.getColor());
+			colorInputControl.setValue(this.tool.getColor());
 			setThickness(this.tool.getThickness());
 
 			penTypeSelect.updateIcons();

--- a/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
@@ -167,7 +167,7 @@ export default class PenToolWidget extends BaseToolWidget {
 
 
 	// Creates a widget that allows selecting different pen types
-	private createPenTypeSelector(helpOverlay: HelpDisplay) {
+	private createPenTypeSelector(helpOverlay?: HelpDisplay) {
 		const allChoices = this.penTypes.map((penType, index) => {
 			return {
 				id: index,
@@ -196,7 +196,7 @@ export default class PenToolWidget extends BaseToolWidget {
 		penSelector.value.onUpdate(onSelectorUpdate);
 		shapeSelector.value.onUpdate(onSelectorUpdate);
 
-		helpOverlay.registerTextHelpForElements(
+		helpOverlay?.registerTextHelpForElements(
 			[penSelector.getRootElement(), shapeSelector.getRootElement()],
 			this.localizationTable.penDropdown__penTypeHelpText,
 		);
@@ -219,7 +219,7 @@ export default class PenToolWidget extends BaseToolWidget {
 		};
 	}
 
-	protected createStrokeCorrectionOptions(helpOverlay: HelpDisplay) {
+	protected createStrokeCorrectionOptions(helpOverlay?: HelpDisplay) {
 		const container = document.createElement('div');
 		container.classList.add('action-button-row', `${toolbarCSSPrefix}-pen-tool-toggle-buttons`);
 
@@ -251,7 +251,7 @@ export default class PenToolWidget extends BaseToolWidget {
 					onChangeListener = listener;
 				},
 				addHelpText(text: string) {
-					helpOverlay.registerTextHelpForElement(button, text);
+					helpOverlay?.registerTextHelpForElement(button, text);
 				},
 			};
 			button.onclick = () => {
@@ -293,18 +293,14 @@ export default class PenToolWidget extends BaseToolWidget {
 		};
 	}
 
-	protected override fillDropdown(dropdown: HTMLElement): boolean {
+	protected override getHelpText() {
+		return this.localizationTable.penDropdown__baseHelpText;
+	}
+
+	protected override fillDropdown(dropdown: HTMLElement, helpDisplay?: HelpDisplay): boolean {
 		const container = document.createElement('div');
 		container.classList.add(
 			`${toolbarCSSPrefix}spacedList`, `${toolbarCSSPrefix}nonbutton-controls-main-list`
-		);
-
-		const helpOverlay = new HelpDisplay(
-			element => this.editor.createHTMLOverlay(element),
-			this.editor,
-		);
-		helpOverlay.registerTextHelpForElement(
-			dropdown, [this.getTitle(), this.localizationTable.penDropdown__baseHelpText].join('\n\n')
 		);
 
 		// Thickness: Value of the input is squared to allow for finer control/larger values.
@@ -328,17 +324,17 @@ export default class PenToolWidget extends BaseToolWidget {
 		colorRow.appendChild(colorInputContainer);
 
 		// Autocorrect and stabilization options
-		const toggleButtonRow = this.createStrokeCorrectionOptions(helpOverlay);
+		const toggleButtonRow = this.createStrokeCorrectionOptions(helpDisplay);
 
-		const penTypeSelect = this.createPenTypeSelector(helpOverlay);
+		const penTypeSelect = this.createPenTypeSelector(helpDisplay);
 
 		// Add help text for color and thickness last, as these are likely to be
 		// features users are least interested in.
-		helpOverlay.registerTextHelpForElement(
+		helpDisplay?.registerTextHelpForElement(
 			colorRow,
 			this.localizationTable.penDropdown__colorHelpText
 		);
-		helpOverlay.registerTextHelpForElement(
+		helpDisplay?.registerTextHelpForElement(
 			thicknessRow, this.localizationTable.penDropdown__thicknessHelpText,
 		);
 
@@ -358,7 +354,7 @@ export default class PenToolWidget extends BaseToolWidget {
 		container.replaceChildren(colorRow, thicknessRow);
 		penTypeSelect.addTo(container);
 
-		dropdown.replaceChildren(helpOverlay.createToggleButton(), container);
+		dropdown.replaceChildren(container);
 
 		// Add the toggle button row *outside* of the main content (use different
 		// spacing with respect to the sides of the container).

--- a/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/PenToolWidget.ts
@@ -167,7 +167,7 @@ export default class PenToolWidget extends BaseToolWidget {
 
 
 	// Creates a widget that allows selecting different pen types
-	private createPenTypeSelector() {
+	private createPenTypeSelector(helpOverlay: HelpDisplay) {
 		const allChoices = this.penTypes.map((penType, index) => {
 			return {
 				id: index,
@@ -195,6 +195,11 @@ export default class PenToolWidget extends BaseToolWidget {
 
 		penSelector.value.onUpdate(onSelectorUpdate);
 		shapeSelector.value.onUpdate(onSelectorUpdate);
+
+		helpOverlay.registerTextHelpForElements(
+			[penSelector.getRootElement(), shapeSelector.getRootElement()],
+			this.localizationTable.penDropdown__penTypeHelpText,
+		);
 
 		return {
 			setValue: (penTypeIndex: number) => {
@@ -263,7 +268,6 @@ export default class PenToolWidget extends BaseToolWidget {
 		stabilizationOption.setOnInputListener(enabled => {
 			this.tool.setHasStabilization(enabled);
 		});
-		stabilizationOption.addHelpText('Draws smoother strokes');
 
 		const autocorrectOption = addToggleButton(
 			this.localizationTable.strokeAutocorrect,
@@ -272,9 +276,10 @@ export default class PenToolWidget extends BaseToolWidget {
 		autocorrectOption.setOnInputListener(enabled => {
 			this.tool.setStrokeAutocorrectEnabled(enabled);
 		});
-		autocorrectOption.addHelpText(
-			'When “Autocorrect” is enabled, holding the pen stationary corrects strokes to rectangles and lines.'
-		);
+
+		// Help text
+		autocorrectOption.addHelpText(this.localizationTable.penDropdown__autocorrectHelpText);
+		stabilizationOption.addHelpText(this.localizationTable.penDropdown__stabilizationHelpText);
 
 		return {
 			update: () => {
@@ -298,14 +303,14 @@ export default class PenToolWidget extends BaseToolWidget {
 			element => this.editor.createHTMLOverlay(element),
 			this.editor,
 		);
-		helpOverlay.registerTextHelpForElement(dropdown, 'Pen tool');
+		helpOverlay.registerTextHelpForElement(
+			dropdown, [this.getTitle(), this.localizationTable.penDropdown__baseHelpText].join('\n')
+		);
 
 		// Thickness: Value of the input is squared to allow for finer control/larger values.
 		const { container: thicknessRow, setValue: setThickness } = makeThicknessSlider(this.editor, thickness => {
 			this.tool.setThickness(thickness);
 		});
-
-		const penTypeSelect = this.createPenTypeSelector();
 
 		const colorRow = document.createElement('div');
 		const colorLabel = document.createElement('label');
@@ -322,9 +327,21 @@ export default class PenToolWidget extends BaseToolWidget {
 		colorRow.appendChild(colorLabel);
 		colorRow.appendChild(colorInputContainer);
 
-		helpOverlay.registerTextHelpForElement(colorRow, 'Select the color of the pen');
-
+		// Autocorrect and stabilization options
 		const toggleButtonRow = this.createStrokeCorrectionOptions(helpOverlay);
+
+		const penTypeSelect = this.createPenTypeSelector(helpOverlay);
+
+		// Add help text for color and thickness last, as these are likely to be
+		// features users are least interested in.
+		helpOverlay.registerTextHelpForElement(
+			colorRow,
+			this.localizationTable.penDropdown__colorHelpText
+		);
+		helpOverlay.registerTextHelpForElement(
+			thicknessRow, this.localizationTable.penDropdown__thicknessHelpText,
+		);
+
 
 		this.updateInputs = () => {
 			setColorInputValue(this.tool.getColor());

--- a/packages/js-draw/src/toolbar/widgets/SelectionToolWidget.ts
+++ b/packages/js-draw/src/toolbar/widgets/SelectionToolWidget.ts
@@ -189,7 +189,7 @@ export default class SelectionToolWidget extends BaseToolWidget {
 	}
 
 	protected override getHelpText(): string {
-		return 'Selects content and manipulates the selection';
+		return this.localizationTable.selectionDropdown__baseHelpText;
 	}
 
 	protected override fillDropdown(dropdown: HTMLElement, helpDisplay?: HelpDisplay): boolean {

--- a/packages/js-draw/src/toolbar/widgets/components/makeColorInput.scss
+++ b/packages/js-draw/src/toolbar/widgets/components/makeColorInput.scss
@@ -53,6 +53,13 @@ $pipette-button-size: 30px;
 	display: inline-flex;
 }
 
+.color-input-container {
+	> .color-input-wrapper {
+		display: flex;
+		justify-content: stretch;
+	}
+}
+
 .color-input-container .pipetteButton > svg {
 	width: 100%;
 }

--- a/packages/js-draw/src/toolbar/widgets/components/makeGridSelector.ts
+++ b/packages/js-draw/src/toolbar/widgets/components/makeGridSelector.ts
@@ -13,8 +13,17 @@ interface GridSelectChoice<ChoiceIdType> {
 
 interface GridSelector<ChoiceIdType> {
 	value: MutableReactiveValue<ChoiceIdType>,
+
+	/**
+	 * Connects this grid selector with `other` such that only one item in
+	 * either this or `other` can be selected at a time.
+	 */
 	linkWith: (other: GridSelector<ChoiceIdType>)=>void;
+
+	/** Re-builds the icons shown in the grid selector. */
 	updateIcons: ()=>void;
+
+	getRootElement: ()=>HTMLElement;
 	addTo: (parent: HTMLElement)=>void;
 
 	/** Used internally @internal */
@@ -188,6 +197,10 @@ const makeGridSelector = <ChoiceIdType> (
 
 		updateIcons: () => {
 			buttons.forEach(button => button.updateIcon());
+		},
+
+		getRootElement() {
+			return outerContainer;
 		},
 
 		addTo: (parent: HTMLElement) => {

--- a/packages/js-draw/src/util/addLongPressOrHoverCssClasses.ts
+++ b/packages/js-draw/src/util/addLongPressOrHoverCssClasses.ts
@@ -6,7 +6,7 @@ import listenForLongPressOrHover from './listenForLongPressOrHover';
  *
  * When no pointers are inside `element`, adds the CSS class `no-long-press-or-hover`.
  */
-const addLongPressOrHoverCssClasses = (element: HTMLElement) => {
+const addLongPressOrHoverCssClasses = (element: HTMLElement, options?: { timeout: number, }) => {
 	const hasLongPressClass = 'has-long-press-or-hover';
 	const noLongPressClass = 'no-long-press-or-hover';
 
@@ -21,6 +21,7 @@ const addLongPressOrHoverCssClasses = (element: HTMLElement) => {
 			element.classList.add(noLongPressClass);
 			element.classList.remove(hasLongPressClass);
 		},
+		longPressTimeout: options?.timeout,
 	});
 
 	return {

--- a/packages/js-draw/src/util/cloneElementWithStyles.ts
+++ b/packages/js-draw/src/util/cloneElementWithStyles.ts
@@ -7,7 +7,11 @@ const cloneElementWithStyles = (element: HTMLElement) => {
 	const restyle = (originalElement: HTMLElement, clonedElement: HTMLElement) => {
 		const originalComputedStyle = getComputedStyle(originalElement);
 
-		for (const propertyName of originalComputedStyle) {
+		// jsdom doesn't support iterators in CSSStyleDeclarations. Iterate with
+		// an index.
+		for (let index = 0; index < originalComputedStyle.length; index++) {
+			const propertyName = originalComputedStyle.item(index);
+
 			const propertyValue = originalComputedStyle.getPropertyValue(propertyName);
 			clonedElement.style.setProperty(propertyName, propertyValue);
 		}

--- a/packages/js-draw/src/util/cloneElementWithStyles.ts
+++ b/packages/js-draw/src/util/cloneElementWithStyles.ts
@@ -1,0 +1,32 @@
+
+/**
+ * Makes a clone of `element` and recursively applies styles from the original to the
+ * clone's children.
+ */
+const cloneElementWithStyles = (element: HTMLElement) => {
+	const restyle = (originalElement: HTMLElement, clonedElement: HTMLElement) => {
+		const originalComputedStyle = getComputedStyle(originalElement);
+
+		for (const propertyName of originalComputedStyle) {
+			const propertyValue = originalComputedStyle.getPropertyValue(propertyName);
+			clonedElement.style.setProperty(propertyName, propertyValue);
+		}
+
+		for (let i = 0; i < originalElement.children.length; i++) {
+			const originalChild = originalElement.children.item(i) as HTMLElement;
+			const clonedChild = clonedElement.children.item(i) as HTMLElement;
+
+			if (originalChild && clonedChild) {
+				restyle(originalChild, clonedChild);
+			} else {
+				console.warn('CloneElement: Missing child');
+			}
+		}
+	};
+
+	const elementClone = element.cloneNode(true) as HTMLElement;
+	restyle(element, elementClone);
+	return elementClone;
+};
+
+export default cloneElementWithStyles;

--- a/testing/beforeEachFile.ts
+++ b/testing/beforeEachFile.ts
@@ -49,3 +49,14 @@ window.PointerEvent ??= class extends MouseEvent {
 HTMLElement.prototype.setPointerCapture ??= () => {};
 // eslint-disable-next-line @typescript-eslint/unbound-method
 HTMLElement.prototype.releasePointerCapture ??= () => {};
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+HTMLDialogElement.prototype.showModal ??= function() {
+	this.style.display = 'block';
+};
+
+// eslint-disable-next-line @typescript-eslint/unbound-method
+HTMLDialogElement.prototype.close ??= function() {
+	this.style.display = 'none';
+	this.dispatchEvent(new Event('close'));
+};


### PR DESCRIPTION
# Summary

Adds a "help" button that displays information about the current tool's menu.

Currently, only for the pen tool

# Testing <!-- (if applicable) -->
<!--
	Describe what changes have automated tests and what changes don't. If changes lack automated tests, please describe how it can be verified that changes made by this pull request work as expected.
-->

**To-do**

# Screenshots/other information

![screenshot: Help menu open, shows a label for the "Autocorrect" button. The help menu fills the screen and the "Autocorrect" button is bright and the other content is dark. A bright label is on top of the overlay. There are next and previous buttons.](https://github.com/personalizedrefrigerator/js-draw/assets/46334387/65a2b2d2-97b5-49c8-b867-a9eacfea2fe6)

<!--
	If applicable, please include screenshots/screen recordings/other information that may help contributors review this pull request.
-->


Resolves #51.
