### PR TITLE
feat: Copy a PNG image to the clipboard in addition to SVG data in suported browsers

### DIFF
--- a/packages/js-draw/src/inputEvents.ts
+++ b/packages/js-draw/src/inputEvents.ts
@@ -80,7 +80,7 @@ export interface KeyUpEvent extends BaseKeyEvent {
 
 export interface CopyEvent {
 	readonly kind: InputEvtType.CopyEvent;
-	setData(mime: string, data: string): void;
+	setData(mime: string, data: string|Promise<Blob>): void;
 }
 
 export interface PasteEvent {

--- a/packages/js-draw/src/rendering/renderers/CanvasRenderer.ts
+++ b/packages/js-draw/src/rendering/renderers/CanvasRenderer.ts
@@ -312,13 +312,13 @@ export default class CanvasRenderer extends AbstractRenderer {
 	}
 
 	// @internal
-	public static fromViewport(exportViewport: Viewport, options: { canvasSize?: Vec2, maximumCanvasDimen?: number } = {}) {
+	public static fromViewport(exportViewport: Viewport, options: { canvasSize?: Vec2, maxCanvasDimen?: number } = {}) {
 		const canvas = document.createElement('canvas');
 
 		const exportRectSize = exportViewport.getScreenRectSize();
 		let canvasSize = options.canvasSize ?? exportRectSize;
-		if (options.maximumCanvasDimen && canvasSize.maximumEntryMagnitude() > options.maximumCanvasDimen) {
-			canvasSize = canvasSize.times(options.maximumCanvasDimen / canvasSize.maximumEntryMagnitude());
+		if (options.maxCanvasDimen && canvasSize.maximumEntryMagnitude() > options.maxCanvasDimen) {
+			canvasSize = canvasSize.times(options.maxCanvasDimen / canvasSize.maximumEntryMagnitude());
 		}
 
 		canvas.width = canvasSize.x;

--- a/packages/js-draw/src/rendering/renderers/CanvasRenderer.ts
+++ b/packages/js-draw/src/rendering/renderers/CanvasRenderer.ts
@@ -310,4 +310,26 @@ export default class CanvasRenderer extends AbstractRenderer {
 
 		return bothTooSmall || anyTooSmall;
 	}
+
+	// @internal
+	public static fromViewport(exportViewport: Viewport, options: { canvasSize?: Vec2, maximumCanvasDimen?: number } = {}) {
+		const canvas = document.createElement('canvas');
+
+		const exportRectSize = exportViewport.getScreenRectSize();
+		let canvasSize = options.canvasSize ?? exportRectSize;
+		if (options.maximumCanvasDimen && canvasSize.maximumEntryMagnitude() > options.maximumCanvasDimen) {
+			canvasSize = canvasSize.times(options.maximumCanvasDimen / canvasSize.maximumEntryMagnitude());
+		}
+
+		canvas.width = canvasSize.x;
+		canvas.height = canvasSize.y;
+
+		const ctx = canvas.getContext('2d')!;
+
+		// Scale to ensure that the entire output is visible.
+		const scaleFactor = Math.min(canvasSize.x / exportRectSize.x, canvasSize.y / exportRectSize.y);
+		ctx.scale(scaleFactor, scaleFactor);
+
+		return { renderer: new CanvasRenderer(ctx, exportViewport), element: canvas };
+	}
 }

--- a/packages/js-draw/src/tools/PasteHandler.ts
+++ b/packages/js-draw/src/tools/PasteHandler.ts
@@ -50,16 +50,20 @@ export default class PasteHandler extends BaseTool {
 	}
 
 	private async doSVGPaste(data: string) {
-		const loader = SVGLoader.fromString(data, true);
+		this.editor.showLoadingWarning(0);
+		try {
+			const loader = SVGLoader.fromString(data, true);
 
-		const components: AbstractComponent[] = [];
+			const components: AbstractComponent[] = [];
+			await loader.start((component) => {
+				components.push(component);
+			},
+			(_countProcessed: number, _totalToProcess: number) => null);
 
-		await loader.start((component) => {
-			components.push(component);
-		},
-		(_countProcessed: number, _totalToProcess: number) => null);
-
-		await this.addComponentsFromPaste(components);
+			await this.addComponentsFromPaste(components);
+		} finally {
+			this.editor.hideLoadingWarning();
+		}
 	}
 
 	private async doTextPaste(text: string) {

--- a/packages/js-draw/src/tools/PasteHandler.ts
+++ b/packages/js-draw/src/tools/PasteHandler.ts
@@ -29,7 +29,7 @@ export default class PasteHandler extends BaseTool {
 	public override onPaste(event: PasteEvent): boolean {
 		const mime = event.mime.toLowerCase();
 
-		if (mime === 'image/svg+xml') {
+		if (mime === 'image/svg+xml' || mime === 'text/html') {
 			void this.doSVGPaste(event.data);
 			return true;
 		}
@@ -50,8 +50,7 @@ export default class PasteHandler extends BaseTool {
 	}
 
 	private async doSVGPaste(data: string) {
-		const sanitize = true;
-		const loader = SVGLoader.fromString(data, sanitize);
+		const loader = SVGLoader.fromString(data, true);
 
 		const components: AbstractComponent[] = [];
 

--- a/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
+++ b/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
@@ -5,6 +5,7 @@ import { EditorEventType } from '../../types';
 import { CopyEvent, KeyPressEvent, KeyUpEvent, PointerEvt } from '../../inputEvents';
 import Viewport from '../../Viewport';
 import BaseTool from '../BaseTool';
+import CanvasRenderer from '../../rendering/renderers/CanvasRenderer';
 import SVGRenderer from '../../rendering/renderers/SVGRenderer';
 import Selection from './Selection';
 import TextComponent from '../../components/TextComponent';
@@ -483,10 +484,18 @@ export default class SelectionTool extends BaseTool {
 
 		const sanitize = true;
 		const { element: svgExportElem, renderer: svgRenderer } = SVGRenderer.fromViewport(exportViewport, sanitize);
+		const { element: canvas, renderer: canvasRenderer } = CanvasRenderer.fromViewport(
+			exportViewport,
+			{
+				canvasSize: this.selectionBox.getScreenRegion().size,
+				maximumCanvasDimen: 2048,
+			},
+		);
 
 		const text: string[] = [];
 		for (const elem of selectedElems) {
 			elem.render(svgRenderer);
+			elem.render(canvasRenderer);
 
 			if (elem instanceof TextComponent) {
 				text.push(elem.getText());
@@ -495,6 +504,15 @@ export default class SelectionTool extends BaseTool {
 
 		event.setData('image/svg+xml', svgExportElem.outerHTML);
 		event.setData('text/html', svgExportElem.outerHTML);
+		event.setData('image/png', new Promise<Blob>((resolve, reject) => {
+			canvas.toBlob((blob) => {
+				if (blob) {
+					resolve(blob);
+				} else {
+					reject();
+				}
+			}, 'image/png');
+		}));
 		if (text.length > 0) {
 			event.setData('text/plain', text.join('\n'));
 		}

--- a/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
+++ b/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
@@ -488,7 +488,7 @@ export default class SelectionTool extends BaseTool {
 			exportViewport,
 			{
 				canvasSize: this.selectionBox.getScreenRegion().size,
-				maximumCanvasDimen: 2048,
+				maxCanvasDimen: 2048,
 			},
 		);
 

--- a/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
+++ b/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
@@ -509,7 +509,7 @@ export default class SelectionTool extends BaseTool {
 				if (blob) {
 					resolve(blob);
 				} else {
-					reject();
+					reject('Failed to convert canvas to blob.');
 				}
 			}, 'image/png');
 		}));

--- a/packages/js-draw/src/tools/ToolController.ts
+++ b/packages/js-draw/src/tools/ToolController.ts
@@ -145,14 +145,22 @@ export default class ToolController implements InputEventListener {
 		});
 	}
 
-	// Add a tool to the end of this' tool list (the added tool receives events after tools already added to this).
-	// This should be called before creating the app's toolbar.
-	//
-	// A tool should only be added once.
-	public addTool(tool: BaseTool) {
+	/**
+	 * Add a tool to the end of this' tool list (the added tool receives events after tools already added to this).
+	 * This should be called before creating the app's toolbar.
+	 *
+	 * If `options.addToFront`, the tool is added to the beginning of this' tool list.
+	 *
+	 * Does nothing if the tool is already present.
+	 */
+	public addTool(tool: BaseTool, options?: { addToFront: boolean }) {
 		// Only add if not already present.
 		if (!this.tools.includes(tool)) {
-			this.tools.push(tool);
+			if (options?.addToFront) {
+				this.tools.splice(0, 0, tool);
+			} else {
+				this.tools.push(tool);
+			}
 		}
 	}
 

--- a/packages/js-draw/src/util/ClipboardHandler.test.ts
+++ b/packages/js-draw/src/util/ClipboardHandler.test.ts
@@ -1,0 +1,146 @@
+import BaseTool from '../tools/BaseTool';
+import createEditor from '../testing/createEditor';
+import ClipboardHandler from './ClipboardHandler';
+import { CopyEvent } from '../inputEvents';
+import Editor from '../Editor';
+
+type ClipboardTestData = Record<string, string|Blob>;
+
+// A tool that handles all copy events
+class TestCopyTool extends BaseTool {
+	public constructor(editor: Editor, private data: ClipboardTestData) {
+		super(editor.notifier, 'copy tool');
+	}
+
+	public override onCopy(event: CopyEvent): boolean {
+		for (const key in this.data) {
+			const data = this.data[key];
+			if (typeof data === 'string') {
+				event.setData(key, data);
+			} else {
+				event.setData(key, Promise.resolve(data));
+			}
+		}
+
+		return true;
+	}
+}
+
+const setUpCopyTool = (editor: Editor, clipboardData: ClipboardTestData) => {
+	const copyTool = new TestCopyTool(editor, clipboardData);
+	editor.toolController.addTool(copyTool);
+	return copyTool;
+};
+
+const originalClipboardItem = window.ClipboardItem;
+const setClipboardApiSupported = (supported: boolean) => {
+	if (supported) {
+		window.ClipboardItem = originalClipboardItem;
+	} else {
+		window.ClipboardItem = undefined as any;
+	}
+};
+
+describe('ClipboardHandler', () => {
+	beforeEach(async () => {
+		setClipboardApiSupported(true);
+		await navigator.clipboard.write([]);
+	});
+
+	describe('copy', () => {
+		it('should copy to the clipboard API when no event is given', async () => {
+			const editor = createEditor();
+			setUpCopyTool(editor, {
+				'text/plain': 'Test.',
+			});
+
+			const clipboardHandler = new ClipboardHandler(editor);
+
+			await clipboardHandler.copy();
+
+			expect(await navigator.clipboard.readText()).toBe('Test.');
+		});
+
+		it('should copy to the clipboard API when images are to be copied', async () => {
+			const editor = createEditor();
+			setUpCopyTool(editor, {
+				'text/plain': 'Testing!',
+				'text/html': '<i>Testing!</i>',
+				'image/png': 'Fake image.',
+			});
+			const clipboardHandler = new ClipboardHandler(editor);
+
+			const event = new ClipboardEvent('copy', { clipboardData: new DataTransfer() });
+			await clipboardHandler.copy(event);
+
+			// Should not have written to the clipboard event
+			expect(event.clipboardData?.getData('text/plain')).toBe('');
+			expect(event.clipboardData?.getData('text/html')).toBe('');
+
+			// Should have written to navigator.clipboard
+			const clipboardItems = await navigator.clipboard.read();
+			const itemTypes = clipboardItems.map(item => item.types).flat();
+			expect(itemTypes).toContain('image/png');
+			expect(itemTypes).toContain('text/plain');
+			expect(itemTypes).toContain('text/html');
+		});
+
+		it.each([
+			[{
+				'text/plain': 'Testing!',
+				'text/html': '<i>Testing!</i>',
+			}],
+			[{
+				'text/plain': 'Test 2',
+				'text/html': '<i>...</i>',
+
+				// image/svg+xml is a text format, so shouldn't cause navigator.clipboard to be used
+				'image/svg+xml': 'test',
+			}]
+		])('should use event.dataTransfer when no images are to be copied (case %#)', async (data) => {
+			const editor = createEditor();
+			setUpCopyTool(editor, data);
+			const clipboardHandler = new ClipboardHandler(editor);
+
+			const event = new ClipboardEvent('copy', { clipboardData: new DataTransfer() });
+			await clipboardHandler.copy(event);
+
+			expect(event.clipboardData?.getData('text/plain')).toBe(data['text/plain']);
+			expect(event.clipboardData?.getData('text/html')).toBe(data['text/html']);
+		});
+
+		it('should use event.dataTransfer when the clipboard API is unsupported', async () => {
+			setClipboardApiSupported(false);
+
+			const editor = createEditor();
+			setUpCopyTool(editor, {
+				'text/plain': 'This should be copied.',
+				'image/png': 'Fake image.',
+			});
+
+			const clipboardHandler = new ClipboardHandler(editor);
+
+			const event = new ClipboardEvent('copy', { clipboardData: new DataTransfer() });
+			await clipboardHandler.copy(event);
+
+			expect(event.clipboardData?.getData('text/plain')).toBe('This should be copied.');
+			expect(await navigator.clipboard.read()).toHaveLength(0);
+		});
+
+		// image/svg+xml is unsupported in Chrome as of early 2024.
+		it('should copy text/html instead of image/svg+xml when copying to the Clipboard API', async () => {
+			const editor = createEditor();
+			setUpCopyTool(editor, {
+				'image/svg+xml': '<svg>This should be copied.</svg>',
+			});
+
+			const clipboardHandler = new ClipboardHandler(editor);
+
+			await clipboardHandler.copy();
+
+			const clipboardItems = await navigator.clipboard.read();
+			expect(clipboardItems).toHaveLength(1);
+			expect(await (await clipboardItems[0].getType('text/html')).text()).toBe('<svg>This should be copied.</svg>');
+		});
+	});
+});

--- a/packages/js-draw/src/util/ClipboardHandler.ts
+++ b/packages/js-draw/src/util/ClipboardHandler.ts
@@ -1,0 +1,188 @@
+
+import { Editor } from '../Editor';
+import { InputEvtType } from '../inputEvents';
+import fileToBase64Url from './fileToBase64Url';
+
+export default class ClipboardHandler {
+	#preferClipboardEvents = false;
+
+	public constructor(private editor: Editor) {
+	}
+
+	/**
+	 * Pastes data from the clipboard into the editor associated with
+	 * this handler.
+	 *
+	 * @param event Optional -- a clipboard/drag event. If not provided,
+	 * 				`navigator.clipboard` will be used instead.
+	 * @returns true if the paste event was handled by the editor.
+	 */
+	public async paste(event?: DragEvent|ClipboardEvent) {
+		const editor = this.editor;
+
+		const clipboardData: DataTransfer|null = (event as any)?.dataTransfer ?? (event as any)?.clipboardData ?? null;
+		const hasEvent = !!clipboardData;
+
+		const sendPasteEvent = (mime: string, data: string|null) => {
+			return data && editor.toolController.dispatchInputEvent({
+				kind: InputEvtType.PasteEvent,
+				mime,
+				data,
+			});
+		};
+
+		// Listed in order of precedence
+		const supportedMIMEs = [
+			'image/svg+xml',
+			'text/html',
+			'image/png',
+			'image/jpeg',
+			'text/plain',
+		];
+
+		let files: Blob[] = [];
+		const textData: Map<string, string> = new Map<string, string>();
+		if (hasEvent) {
+			// NOTE: On some browsers, .getData and .files must be used before any async operations.
+			files = [...clipboardData.files];
+			for (const mime of supportedMIMEs) {
+				const data = clipboardData.getData(mime);
+				if (data) {
+					textData.set(mime, data);
+				}
+			}
+		} else {
+			const clipboardData = await navigator.clipboard.read();
+			for (const item of clipboardData) {
+				for (const mime of item.types) {
+					if (supportedMIMEs.includes(mime)) {
+						files.push(await item.getType(mime));
+					}
+				}
+			}
+		}
+
+		// Returns true if handled
+		const handleMIME = async (mime: string) => {
+			const isTextFormat = mime.endsWith('+xml') || mime.startsWith('text/');
+			if (isTextFormat) {
+				const data = textData.get(mime)!;
+
+				if (sendPasteEvent(mime, data)) {
+					event?.preventDefault();
+					return true;
+				}
+			}
+
+			for (const file of files) {
+				const fileType = file.type.toLowerCase();
+				if (fileType !== mime) {
+					continue;
+				}
+
+				if (isTextFormat) {
+					const text = await file.text();
+					if (sendPasteEvent(mime, text)) {
+						event?.preventDefault();
+						return true;
+					}
+				} else {
+					editor.showLoadingWarning(0);
+					const onprogress = (evt: ProgressEvent<FileReader>) => {
+						editor.showLoadingWarning(evt.loaded / evt.total);
+					};
+
+					try {
+						const data = await fileToBase64Url(file, { onprogress });
+
+						if (sendPasteEvent(mime, data)) {
+							event?.preventDefault();
+							editor.hideLoadingWarning();
+							return true;
+						}
+					} catch (e) {
+						console.error('Error reading image:', e);
+					}
+					editor.hideLoadingWarning();
+				}
+			}
+			return false;
+		};
+
+		for (const mime of supportedMIMEs) {
+			if (await handleMIME(mime)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Copies text from the editor associated with this.
+	 *
+	 * Even if `event` is provided, the `navigator.clipboard` API may be used if image data
+	 * is to be copied. This is done because `ClipboardEvent`s seem to not support attaching
+	 * images.
+	 */
+	public async copy(event?: ClipboardEvent) {
+		const mimeToData: Record<string, Promise<Blob>|string> = Object.create(null);
+
+		if (this.editor.toolController.dispatchInputEvent({
+			kind: InputEvtType.CopyEvent,
+			setData: (mime, data) => {
+				mimeToData[mime] = data;
+			},
+		})) {
+			event?.preventDefault();
+		}
+
+		const mimeTypes = Object.keys(mimeToData);
+		const hasNonTextMimeTypes = mimeTypes.some(mime => !mime.startsWith('text/'));
+
+		const copyToEvent = () => {
+			if (!event) {
+				throw new Error('Unable to paste -- no event provided.');
+			}
+
+			for (const key in mimeToData) {
+				const value = mimeToData[key];
+				if (typeof value === 'string') {
+					event.clipboardData?.setData(key, value);
+				}
+			}
+		};
+
+		const copyToClipboardApi = async () => {
+			const mappedMimeToData: Record<string, Blob> = Object.create(null);
+			const mimeMapping: Record<string, string> = {
+				'image/svg+xml': 'text/html',
+			};
+			for (const key in mimeToData) {
+				const data = mimeToData[key];
+				const mappedKey = mimeMapping[key] || key;
+				if (typeof data === 'string') {
+					mappedMimeToData[mappedKey] = new Blob([new TextEncoder().encode(data)], { type: mappedKey });
+				} else {
+					mappedMimeToData[mappedKey] = await data;
+				}
+			}
+			await navigator.clipboard.write([ new ClipboardItem(mappedMimeToData) ]);
+		};
+
+		const supportsClipboardApi = typeof ClipboardItem !== 'undefined';
+		if (!this.#preferClipboardEvents && supportsClipboardApi && (hasNonTextMimeTypes || !event)) {
+			try {
+				await copyToClipboardApi();
+			} catch(error) {
+				console.warn('Unable to copy to the clipboard API. Future calls to .copy will use ClipboardEvents if possible');
+				this.#preferClipboardEvents = true;
+
+				// May not work in some browsers (can't copy to an event after running async code)
+				copyToEvent();
+			}
+		} else {
+			copyToEvent();
+		}
+	}
+}

--- a/packages/js-draw/src/util/ClipboardHandler.ts
+++ b/packages/js-draw/src/util/ClipboardHandler.ts
@@ -7,6 +7,10 @@ const isTextMimeType = (mime: string) =>
 	// +xml: Handles image/svg+xml
 	mime.endsWith('+xml') || mime.startsWith('text/');
 
+/**
+ * Handles conversion between the browser clipboard APIs and internal
+ * js-draw clipboard events.
+ */
 export default class ClipboardHandler {
 	#preferClipboardEvents = false;
 

--- a/testing/beforeEachFile.ts
+++ b/testing/beforeEachFile.ts
@@ -2,6 +2,13 @@ import loadExpectExtensions from './loadExpectExtensions';
 loadExpectExtensions();
 jest.useFakeTimers();
 
+// jsdom hides several node APIs that should be present in the browser.
+import { TextEncoder, TextDecoder } from 'node:util';
+import { Blob as NodeBlob } from 'node:buffer';
+window.TextEncoder = TextEncoder;
+window.TextDecoder = TextDecoder as any;
+window.Blob = NodeBlob as any;
+
 // jsdom doesn't support HTMLCanvasElement#getContext — it logs an error
 // to the console. Make it return null so we can handle a non-existent Canvas
 // at runtime (e.g. use something else, if available).
@@ -60,3 +67,92 @@ HTMLDialogElement.prototype.close ??= function() {
 	this.style.display = 'none';
 	this.dispatchEvent(new Event('close'));
 };
+
+
+// jsdom doesn't support the clipboard API or ClipboardEvents.
+// For now, these are mocked here:
+
+(Navigator.prototype as any).clipboard ??= {};
+
+let clipboardData: ClipboardItems = [];
+Navigator.prototype.clipboard.read = async (): Promise<ClipboardItems> => {
+	return [...clipboardData];
+};
+Navigator.prototype.clipboard.readText = async (): Promise<string> => {
+	for (const item of clipboardData) {
+		for (const mime of item.types) {
+			if (mime === 'text/plain') {
+				return await (await item.getType(mime)).text();
+			}
+		}
+	}
+
+	return '';
+};
+
+Navigator.prototype.clipboard.write = async (data: ClipboardItems): Promise<void> => {
+	clipboardData = [...data];
+};
+
+window.ClipboardItem ??= class {
+	public readonly types: string[];
+
+	public constructor(
+		public readonly items: Record<string, string|Blob|PromiseLike<string|Blob>>,
+		public readonly options?: ClipboardItemOptions
+	) {
+		this.types = Object.keys(items).map(key => key.toLowerCase());
+	}
+
+	public async getType(type: string) {
+		const value = await this.items[type];
+		if (typeof value === 'string') {
+			return new Blob([new TextEncoder().encode(value)], { type: type });
+		} else {
+			return value;
+		}
+	}
+};
+
+window.ClipboardEvent ??= class extends Event {
+	public clipboardData: DataTransfer|null;
+
+	public constructor(type: string, options?: ClipboardEventInit) {
+		super(type, options);
+		this.clipboardData = options?.clipboardData ?? null;
+	}
+};
+
+window.DataTransfer ??= class {
+	#data: Map<string, string> = new Map();
+
+	public files: File[] = [];
+	public dropEffect = 'none';
+	public effectAllowed = 'uninitialized';
+
+	public get types() {
+		const types = new Set(this.#data.keys());
+		for (const file of this.files) {
+			types.add(file.type);
+		}
+		return [ ...types.values() ];
+	}
+
+	public get items() {
+		return []; // TODO
+	}
+
+	public setData(format: string, value: string) {
+		this.#data.set(format, value);
+	}
+
+	public getData(format: string) {
+		return this.#data.get(format) ?? '';
+	}
+
+	public clearData() {
+		this.#data.clear();
+	}
+
+	public setDragImage() { }
+} as any;


### PR DESCRIPTION
# Summary

- Copies `image/png` data to the clipboard in addition to `text/html` or `image/svg+xml` data in browsers that support `navigator.clipboard.write`
- Refactors paste logic

# To-do

- [x] Automated tests
- [x] Refactoring: move paste handling out of `Editor.ts`
