### PR TITLE
fix(editor): Fix strokes drawn with non-primary styluses never finalized

### DIFF
--- a/packages/js-draw/src/Editor.ts
+++ b/packages/js-draw/src/Editor.ts
@@ -1,7 +1,7 @@
 import EditorImage from './image/EditorImage';
 import ToolController from './tools/ToolController';
 import { EditorNotifier, EditorEventType, ImageLoader } from './types';
-import { HTMLPointerEventName, HTMLPointerEventFilter, InputEvtType, PointerEvt, keyUpEventFromHTMLEvent, keyPressEventFromHTMLEvent } from './inputEvents';
+import { HTMLPointerEventName, HTMLPointerEventFilter, InputEvtType, PointerEvt, keyUpEventFromHTMLEvent, keyPressEventFromHTMLEvent, PointerEvtType } from './inputEvents';
 import Command from './commands/Command';
 import UndoRedoHistory from './UndoRedoHistory';
 import Viewport from './Viewport';
@@ -1324,7 +1324,7 @@ export class Editor {
 	 * @see {@link sendPenEvent} {@link sendTouchEvent}
 	 */
 	public sendPenEvent(
-		eventType: InputEvtType.PointerDownEvt|InputEvtType.PointerMoveEvt|InputEvtType.PointerUpEvt,
+		eventType: PointerEvtType,
 		point: Point2,
 
 		// @deprecated

--- a/packages/js-draw/src/inputEvents.ts
+++ b/packages/js-draw/src/inputEvents.ts
@@ -118,6 +118,9 @@ export interface PointerUpEvt extends PointerEvtBase {
  */
 export type PointerEvt = PointerDownEvt | PointerMoveEvt | PointerUpEvt;
 
+/** The type of any internal {@link PointerEvt} record. */
+export type PointerEvtType = InputEvtType.PointerDownEvt|InputEvtType.PointerMoveEvt|InputEvtType.PointerUpEvt;
+
 /**
  * An internal `js-draw` input event type.
  *

--- a/packages/js-draw/src/testing/sendPenEvent.ts
+++ b/packages/js-draw/src/testing/sendPenEvent.ts
@@ -1,7 +1,7 @@
 import Editor from '../Editor';
 import { Point2 } from '@js-draw/math';
 import Pointer, { PointerDevice } from '../Pointer';
-import { InputEvtType } from '../inputEvents';
+import { InputEvtType, PointerEvtType } from '../inputEvents';
 import getUniquePointerId from './getUniquePointerId';
 
 /**
@@ -12,7 +12,7 @@ import getUniquePointerId from './getUniquePointerId';
  */
 const sendPenEvent = (
 	editor: Editor,
-	eventType: InputEvtType.PointerDownEvt|InputEvtType.PointerMoveEvt|InputEvtType.PointerUpEvt,
+	eventType: PointerEvtType,
 	point: Point2,
 
 	allPointers?: Pointer[],

--- a/packages/js-draw/src/testing/sendTouchEvent.ts
+++ b/packages/js-draw/src/testing/sendTouchEvent.ts
@@ -1,7 +1,7 @@
 import Editor from '../Editor';
 import { Vec2 } from '@js-draw/math';
 import Pointer, { PointerDevice } from '../Pointer';
-import { InputEvtType } from '../inputEvents';
+import { InputEvtType, PointerEvtType } from '../inputEvents';
 import getUniquePointerId from './getUniquePointerId';
 
 /**
@@ -42,7 +42,7 @@ import getUniquePointerId from './getUniquePointerId';
  */
 const sendTouchEvent = (
 	editor: Editor,
-	eventType: InputEvtType.PointerDownEvt|InputEvtType.PointerMoveEvt|InputEvtType.PointerUpEvt,
+	eventType: PointerEvtType,
 	screenPos: Vec2,
 	allOtherPointers?: Pointer[]
 ) => {

--- a/packages/js-draw/src/tools/Eraser.test.ts
+++ b/packages/js-draw/src/tools/Eraser.test.ts
@@ -4,7 +4,7 @@ import { EditorImage, PointerDevice, Rect2, StrokeComponent } from '../lib';
 import { LineSegment2, Point2, Vec2 } from '@js-draw/math';
 import createEditor from '../testing/createEditor';
 import sendPenEvent from '../testing/sendPenEvent';
-import { InputEvtType } from '../inputEvents';
+import { InputEvtType, PointerEvtType } from '../inputEvents';
 import Eraser, { EraserMode } from './Eraser';
 import Pen from './Pen';
 
@@ -18,7 +18,7 @@ const selectEraser = (editor: Editor) => {
 
 const sendEraserEvent = (
 	editor: Editor,
-	eventType: InputEvtType.PointerDownEvt|InputEvtType.PointerMoveEvt|InputEvtType.PointerUpEvt,
+	eventType: PointerEvtType,
 	point: Point2,
 ) => {
 	return sendPenEvent(editor, eventType, point, undefined, PointerDevice.Eraser);


### PR DESCRIPTION
# Summary

This pull request updates `Pen.ts` to finalize strokes only when the pointer that created them is lifted.

Previously, `Pen.ts` incorrectly relied on `isPrimary` to determine whether a pointerup event should cause a stroke to be added to the image or ignored. This could be problematic — nonprimary pointers **can** start strokes. Additionally, in the case of #71, [the primary pointer was not marked with isPrimary](https://github.com/personalizedrefrigerator/js-draw/issues/71#issue-2340637037).

# Testing

An automated test has been added in `Pen.test.ts`. This test should verify that strokes created with a non-primary pen are added to the image.


Fixes #71.
