### PR TITLE
fix(editor): Selection tool: Work around bug where the primary pointer is reported as non-primary on some devices. (#71)

### DIFF
--- a/packages/js-draw/src/tools/SelectionTool/Selection.ts
+++ b/packages/js-draw/src/tools/SelectionTool/Selection.ts
@@ -136,6 +136,7 @@ export default class Selection {
 		return this.originalRegion;
 	}
 
+	// The **canvas** region.
 	public get region(): Rect2 {
 		// TODO: This currently assumes that the region rotates about its center.
 		// This may not be true.

--- a/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
+++ b/packages/js-draw/src/tools/SelectionTool/SelectionTool.ts
@@ -104,7 +104,8 @@ export default class SelectionTool extends BaseTool {
 			current = current.snappedToGrid(this.editor.viewport);
 		}
 
-		if (allPointers.length === 1 && current.isPrimary) {
+		// Don't rely on .isPrimary -- it's buggy in Firefox. See https://github.com/personalizedrefrigerator/js-draw/issues/71
+		if (allPointers.length === 1) {
 			this.startPoint = current.canvasPos;
 
 			let transforming = false;


### PR DESCRIPTION
# Summary

Allows using non-primary pointers to start a selection.

> [!NOTE]
> According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/isPrimary), for pens,
> > A pointer is considered primary if the pointer represents a mouse device. A pointer representing pen input is considered the primary pen input if its [pointerdown](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerdown_event) event was dispatched when no other active pointers representing pen input existed.
>
> Also see [the spec](https://w3c.github.io/pointerevents/#dfn-primary-pointer).
>
> As such, the issue described in #71 is likely related to an upstream bug.

# Testing

This pull request a regression test and a test that should verify that pinch-zoom continues to cancel creating a selection.

Resolves #71
