### PR TITLE
chore: Add the eslint-no-unsanitized rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
 		'eslint:recommended',
 		'plugin:@typescript-eslint/eslint-recommended',
 		'plugin:@typescript-eslint/recommended',
+		'plugin:no-unsanitized/recommended-legacy',
 		'eslint-config-prettier',
 	],
 	// See https://typescript-eslint.io/linting/troubleshooting/#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

--- a/docs/demo/icons.ts
+++ b/docs/demo/icons.ts
@@ -41,11 +41,16 @@ export const makeIconFromText = (text: string) => {
 
 export const makeLocalStorageIcon = () => {
 	const elem = document.createElementNS(svgNamespace, 'svg');
-	const iconFillSStyle = 'style="fill: var(--icon-color);"';
-	elem.innerHTML = `
-		<path d="M 50,10 V 60 H 35 L 55,85 75,60 H 60 V 10 Z" ${iconFillSStyle}/>
-		<path d="m 15,85 v 10 h 85 V 85 Z" ${iconFillSStyle}/>
-	`;
+
+	const makePath = (d: string) => {
+		const path = document.createElementNS(svgNamespace, 'path');
+		path.style.fill = 'var(--icon-color)';
+		path.setAttribute('d', d);
+		elem.appendChild(path);
+	};
+
+	makePath('M 50,10 V 60 H 35 L 55,85 75,60 H 60 V 10 Z');
+	makePath('m 15,85 v 10 h 85 V 85 Z');
 	elem.setAttribute('viewBox', '5 0 100 100');
 
 	return elem;

--- a/docs/demo/ui/makeNewImageDialog.ts
+++ b/docs/demo/ui/makeNewImageDialog.ts
@@ -87,10 +87,11 @@ const makeNewImageDialog = (
 		const templateButton = document.createElement('button');
 		templateButton.classList.add('new-image-template-button');
 
-		const icon = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-		icon.innerHTML = svgData;
+		const icon = new Image();
+		icon.classList.add('icon');
+		icon.src = `data:image/svg+xml;utf8,${encodeURIComponent(svgData)}`;
 		const label = document.createElement('div');
-		label.innerText = title;
+		label.textContent = title;
 
 		templateButton.onclick = () => {
 			closeDialogWithStringResult(svgData);

--- a/docs/demo/ui/newImageDialog.css
+++ b/docs/demo/ui/newImageDialog.css
@@ -14,7 +14,11 @@
 }
 
 .new-image-template-button .icon {
-	width: 95%;
+	width: 300px;
+	height: 150px;
+
+	object-position: left top;
+	object-fit: none; /* Do not resize to fit container */
 }
 
 .new-image-template-button:hover {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"@typescript-eslint/parser": "8.4.0",
 		"eslint": "8.57.0",
 		"eslint-config-prettier": "9.1.0",
+		"eslint-plugin-no-unsanitized": "4.1.2",
 		"jest": "29.7.0",
 		"jest-environment-jsdom": "29.7.0",
 		"jsdom": "25.0.0",

--- a/packages/js-draw/src/SVGLoader/SVGLoader.ts
+++ b/packages/js-draw/src/SVGLoader/SVGLoader.ts
@@ -700,6 +700,7 @@ export default class SVGLoader implements ImageLoader {
 		const { svgElem, cleanUp } = (() => {
 			// If the user requested an iframe load (the default) try to load with an iframe.
 			// There are some cases (e.g. in a sandboxed iframe) where this doesn't work.
+			// TODO(v2): Use domParserLoad by default.
 			if (!domParserLoad) {
 				try {
 					const sandbox = document.createElement('iframe');
@@ -744,6 +745,7 @@ export default class SVGLoader implements ImageLoader {
 					sandboxDoc.close();
 
 					const svgElem = sandboxDoc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+					// eslint-disable-next-line no-unsanitized/property -- setting innerHTML in a sandboxed document.
 					svgElem.innerHTML = text;
 					sandboxDoc.body.appendChild(svgElem);
 

--- a/packages/js-draw/src/rendering/renderers/SVGRenderer.ts
+++ b/packages/js-draw/src/rendering/renderers/SVGRenderer.ts
@@ -71,7 +71,9 @@ export default class SVGRenderer extends AbstractRenderer {
 		if (!this.elem.querySelector(`#${renderedStylesheetId}`)) {
 			// Default to rounded strokes.
 			const styleSheet = document.createElementNS('http://www.w3.org/2000/svg', 'style');
-			styleSheet.innerHTML = `
+			styleSheet.appendChild(
+				document.createTextNode(
+					`
 				path {
 					stroke-linecap: round;
 					stroke-linejoin: round;
@@ -80,7 +82,9 @@ export default class SVGRenderer extends AbstractRenderer {
 				text {
 					white-space: pre;
 				}
-			`.replace(/\s+/g, '');
+			`.replace(/\s+/g, ''),
+				),
+			);
 			styleSheet.setAttribute('id', renderedStylesheetId);
 			this.elem.appendChild(styleSheet);
 		}

--- a/packages/js-draw/src/toolbar/IconProvider.ts
+++ b/packages/js-draw/src/toolbar/IconProvider.ts
@@ -962,6 +962,9 @@ export default class IconProvider {
 	 * @returns An object with both the definition of a checkerboard pattern and the syntax to
 	 * reference that pattern. The defs provided by this function should be wrapped within a
 	 * `<defs></defs>` element.
+	 *
+	 * **Note**: This function's return value includes both `patternDefElement` (which returns
+	 * an Element) and a (deprecated) `patternDef` string. Avoid using the `patternDef` result.
 	 */
 	protected makeCheckerboardPattern() {
 		return makeCheckerboardPattern();

--- a/packages/js-draw/src/util/createElement.ts
+++ b/packages/js-draw/src/util/createElement.ts
@@ -1,5 +1,9 @@
 type ElementTagNames = keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap;
 
+/**
+ * Maps from known elment tag names to options that can be set with .setAttribute.
+ * New elements/properties should be added as necessary.
+ */
 interface ElementToPropertiesMap {
 	path: {
 		d: string;
@@ -29,11 +33,16 @@ type ElementProperties<Tag extends ElementTagNames> = Tag extends keyof ElementT
 	? Partial<ElementToPropertiesMap[Tag]>
 	: EmptyObject;
 
+/** Contains options for creating an element with tag = `Tag`. */
 type ElementConfig<Tag extends ElementTagNames> = ElementProperties<Tag> & {
 	id?: string;
 	children?: (HTMLElement | SVGElement)[];
 };
 
+/**
+ * Maps from element tag names (e.g. `Tag='button'`) to the corresponding element type
+ * (e.g. `HTMLButtonElement`).
+ */
 type ElementTagToType<Tag extends ElementTagNames> = Tag extends keyof HTMLElementTagNameMap
 	? HTMLElementTagNameMap[Tag]
 	: Tag extends keyof SVGElementTagNameMap
@@ -45,6 +54,12 @@ export enum ElementNamespace {
 	Svg = 'svg',
 }
 
+/**
+ * Shorthand for creating an element with `document.createElement`, then assigning properties.
+ *
+ * Non-HTML elements (e.g. `svg` elements) should use the `elementType` parameter to select
+ * the element namespace.
+ */
 const createElement = <Tag extends ElementTagNames>(
 	tag: Tag,
 	props: ElementConfig<Tag>,
@@ -80,7 +95,9 @@ const createElement = <Tag extends ElementTagNames>(
 export const createSvgElement = <Tag extends keyof SVGElementTagNameMap>(
 	tag: Tag,
 	props: ElementConfig<Tag>,
-) => createElement(tag, props, ElementNamespace.Svg);
+) => {
+	return createElement(tag, props, ElementNamespace.Svg);
+};
 
 export const createSvgElements = <Tag extends keyof SVGElementTagNameMap>(
 	tag: Tag,

--- a/packages/js-draw/src/util/createElement.ts
+++ b/packages/js-draw/src/util/createElement.ts
@@ -1,0 +1,96 @@
+type ElementTagNames = keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap;
+
+interface ElementToPropertiesMap {
+	path: {
+		d: string;
+		fill: string;
+		stroke: string;
+		transform: string;
+	};
+	rect: {
+		stroke: string;
+		fill: string;
+		x: number;
+		y: number;
+		width: number;
+		height: number;
+		transform: string;
+	};
+	stop: {
+		offset: string;
+		'stop-color': string;
+	};
+	svg: {
+		viewBox: `${number} ${number} ${number} ${number}`;
+	};
+}
+type EmptyObject = Record<never, never>;
+type ElementProperties<Tag extends ElementTagNames> = Tag extends keyof ElementToPropertiesMap
+	? Partial<ElementToPropertiesMap[Tag]>
+	: EmptyObject;
+
+type ElementConfig<Tag extends ElementTagNames> = ElementProperties<Tag> & {
+	id?: string;
+	children?: (HTMLElement | SVGElement)[];
+};
+
+type ElementTagToType<Tag extends ElementTagNames> = Tag extends keyof HTMLElementTagNameMap
+	? HTMLElementTagNameMap[Tag]
+	: Tag extends keyof SVGElementTagNameMap
+		? SVGElementTagNameMap[Tag]
+		: never;
+
+export enum ElementNamespace {
+	Html = 'html',
+	Svg = 'svg',
+}
+
+const createElement = <Tag extends ElementTagNames>(
+	tag: Tag,
+	props: ElementConfig<Tag>,
+	elementType: ElementNamespace = ElementNamespace.Html,
+): ElementTagToType<Tag> => {
+	let elem: ElementTagToType<Tag>;
+	if (elementType === ElementNamespace.Html) {
+		elem = document.createElement(tag) as ElementTagToType<Tag>;
+	} else if (elementType === ElementNamespace.Svg) {
+		elem = document.createElementNS('http://www.w3.org/2000/svg', tag) as ElementTagToType<Tag>;
+	} else {
+		throw new Error(`Unknown element type ${elementType}`);
+	}
+
+	for (const [key, value] of Object.entries(props)) {
+		if (key === 'children') continue;
+
+		if (typeof value !== 'string' && typeof value !== 'number') {
+			throw new Error(`Unsupported value type ${typeof value}`);
+		}
+		elem.setAttribute(key, value.toString());
+	}
+
+	if (props.children) {
+		for (const item of props.children) {
+			elem.appendChild(item);
+		}
+	}
+
+	return elem;
+};
+
+export const createSvgElement = <Tag extends keyof SVGElementTagNameMap>(
+	tag: Tag,
+	props: ElementConfig<Tag>,
+) => createElement(tag, props, ElementNamespace.Svg);
+
+export const createSvgElements = <Tag extends keyof SVGElementTagNameMap>(
+	tag: Tag,
+	elements: ElementConfig<Tag>[],
+) => {
+	return elements.map((props) => createSvgElement(tag, props));
+};
+
+export const createSvgPaths = (...paths: ElementConfig<'path'>[]) => {
+	return createSvgElements('path', paths);
+};
+
+export default createElement;

--- a/packages/material-icons/src/lib.ts
+++ b/packages/material-icons/src/lib.ts
@@ -59,10 +59,18 @@ import Shapes from './icons/Shapes.svg';
 import Draw from './icons/Draw.svg';
 import InkPen from './icons/InkPen.svg';
 import ContentPaste from './icons/ContentPaste.svg';
+import { OpaqueIconType } from './types';
 
-const icon = (data: string) => {
+/**
+ * Converts an icon to an HTML element.
+ *
+ * This function accepts an "opaque" type to avoid unsafely creating icon DOM elements
+ * from untrusted strings.
+ */
+const icon = (data: OpaqueIconType) => {
 	const icon = document.createElement('div');
-	icon.innerHTML = data;
+	// eslint-disable-next-line no-unsanitized/property -- data must not be user-provided (enforced with a custom type).
+	icon.innerHTML = data as unknown as string;
 	return icon.childNodes[0] as SVGElement;
 };
 
@@ -139,7 +147,7 @@ class MaterialIconProvider extends IconProvider {
 		if (style.color.a < 1) {
 			const checkerboard = this.makeCheckerboardPattern();
 			const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs');
-			defs.innerHTML = checkerboard.patternDef;
+			defs.appendChild(checkerboard.patternDefElement());
 			svg.appendChild(defs);
 
 			const lineBackground = line.cloneNode() as SVGPathElement;

--- a/packages/material-icons/src/types.ts
+++ b/packages/material-icons/src/types.ts
@@ -1,0 +1,11 @@
+/**
+ * All auto-generated icons should have this type.
+ *
+ * Goal: Ensure that icon processing functions are working with the original
+ * auto-generated Material icons.
+ *
+ * @internal
+ */
+export interface OpaqueIconType {
+	__opaqueType__iconType: unknown;
+}

--- a/packages/material-icons/tools/prebuild.js
+++ b/packages/material-icons/tools/prebuild.js
@@ -35,7 +35,9 @@ const convertIcons = async () => {
 				// modified to set the fill of the icon.
 				// The icon was downloaded from https://fonts.google.com/icons
 
-				export const ${iconName} = ${JSON.stringify(updatedIcon)};
+				import { OpaqueIconType } from '../types';
+
+				export const ${iconName} = ${JSON.stringify(updatedIcon)} as unknown as OpaqueIconType;
 				export default ${iconName};
 			`,
 				);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,6 +1108,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:8.4.0"
     eslint: "npm:8.57.0"
     eslint-config-prettier: "npm:9.1.0"
+    eslint-plugin-no-unsanitized: "npm:4.1.2"
     jest: "npm:29.7.0"
     jest-environment-jsdom: "npm:29.7.0"
     jsdom: "npm:25.0.0"
@@ -4094,6 +4095,15 @@ __metadata:
   bin:
     eslint-config-prettier: bin/cli.js
   checksum: 10c0/6d332694b36bc9ac6fdb18d3ca2f6ac42afa2ad61f0493e89226950a7091e38981b66bac2b47ba39d15b73fff2cd32c78b850a9cf9eed9ca9a96bfb2f3a2f10d
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-no-unsanitized@npm:4.1.2":
+  version: 4.1.2
+  resolution: "eslint-plugin-no-unsanitized@npm:4.1.2"
+  peerDependencies:
+    eslint: ^8 || ^9
+  checksum: 10c0/c62bbfc02e8a73adc7ff9fdbbf8131a2a843eaebc6e8eb5f311c4db8a641bb46535bd066052857c7daea6c6d2a6c38bec66e06ad5704319083a1e2c467e71a4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

This pull request adds Mozilla's [eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized) rule, which flags most usages of `.innerHTML` and `document.write` as unsafe.

**Goals**: 
- Make it more difficult to commit unsafe code.
- Bring `js-draw` closer to working on pages that have a `Content-Security-Policy` containing [`trusted-types`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types). 

# Manual testing

- [x] (Firefox) Default pen icon renders and reacts to pen thickness changes.
- [x] (Firefox) Default eraser icon renders and reacts to eraser thickness/style changes.
- [x] (Firefox) Material toolbar icons render.
