### PR TITLE
feat(editor): Accelerate inking using the web Ink API(#115)

### DIFF
--- a/packages/js-draw/src/Editor.ts
+++ b/packages/js-draw/src/Editor.ts
@@ -731,6 +731,7 @@ export class Editor {
 	): boolean {
 		const eventsRelativeTo = this.renderingRegion;
 		const eventTarget = (evt.target as HTMLElement | null) ?? this.renderingRegion;
+		this.display.onPointerEvent(evt);
 
 		if (eventType === 'pointerdown') {
 			const pointer = Pointer.ofEvent(evt, true, this.viewport, eventsRelativeTo);

--- a/packages/js-draw/src/components/builders/FreehandLineBuilder.ts
+++ b/packages/js-draw/src/components/builders/FreehandLineBuilder.ts
@@ -63,10 +63,14 @@ export default class FreehandLineBuilder implements ComponentBuilder {
 	protected getRenderingStyle(): RenderingStyle {
 		return {
 			fill: Color4.transparent,
-			stroke: {
-				color: this.startPoint.color,
-				width: this.roundDistance(this.averageWidth),
-			},
+			stroke: this.inkTrailStyle(),
+		};
+	}
+
+	public inkTrailStyle() {
+		return {
+			color: this.startPoint.color,
+			width: this.roundDistance(this.averageWidth),
 		};
 	}
 

--- a/packages/js-draw/src/components/builders/PolylineBuilder.ts
+++ b/packages/js-draw/src/components/builders/PolylineBuilder.ts
@@ -71,10 +71,14 @@ export default class PolylineBuilder implements ComponentBuilder {
 	protected getRenderingStyle(): RenderingStyle {
 		return {
 			fill: Color4.transparent,
-			stroke: {
-				color: this.startPoint.color,
-				width: this.roundDistance(this.averageWidth),
-			},
+			stroke: this.inkTrailStyle(),
+		};
+	}
+
+	public inkTrailStyle() {
+		return {
+			color: this.startPoint.color,
+			width: this.roundDistance(this.averageWidth),
 		};
 	}
 

--- a/packages/js-draw/src/components/builders/PressureSensitiveFreehandLineBuilder.ts
+++ b/packages/js-draw/src/components/builders/PressureSensitiveFreehandLineBuilder.ts
@@ -109,6 +109,13 @@ export default class PressureSensitiveFreehandLineBuilder implements ComponentBu
 		};
 	}
 
+	public inkTrailStyle() {
+		return {
+			color: this.startPoint.color,
+			width: this.getCurrentRadius() * 2,
+		};
+	}
+
 	private previewCurrentPath(extendWithLatest: boolean = true): RenderablePathSpec | null {
 		const upperPath = this.upperSegments.slice();
 		const lowerPath = this.lowerSegments.slice();
@@ -278,6 +285,13 @@ export default class PressureSensitiveFreehandLineBuilder implements ComponentBu
 		return false;
 	}
 
+	private getCurrentRadius() {
+		return Viewport.roundPoint(
+			this.startPoint.width / 2.2,
+			Math.min(this.minFitAllowed, this.startPoint.width / 4),
+		);
+	}
+
 	private addCurve(curve: Curve | null) {
 		// Case where no points have been added
 		if (!curve) {
@@ -286,45 +300,42 @@ export default class PressureSensitiveFreehandLineBuilder implements ComponentBu
 				return;
 			}
 
-			const width = Viewport.roundPoint(
-				this.startPoint.width / 2.2,
-				Math.min(this.minFitAllowed, this.startPoint.width / 4),
-			);
+			const radius = this.getCurrentRadius();
 			const center = this.roundPoint(this.startPoint.pos);
 
 			// Start on the right, cycle clockwise:
 			//    |
 			//  ----- ←
 			//    |
-			const startPoint = this.startPoint.pos.plus(Vec2.of(width, 0));
+			const startPoint = this.startPoint.pos.plus(Vec2.of(radius, 0));
 
 			// Draw a circle-ish shape around the start point
 			this.lowerSegments.push(
 				{
 					kind: PathCommandType.QuadraticBezierTo,
-					controlPoint: center.plus(Vec2.of(width, width)),
+					controlPoint: center.plus(Vec2.of(radius, radius)),
 
 					// Bottom of the circle
 					//    |
 					//  -----
 					//    |
 					//    ↑
-					endPoint: center.plus(Vec2.of(0, width)),
+					endPoint: center.plus(Vec2.of(0, radius)),
 				},
 				{
 					kind: PathCommandType.QuadraticBezierTo,
-					controlPoint: center.plus(Vec2.of(-width, width)),
-					endPoint: center.plus(Vec2.of(-width, 0)),
+					controlPoint: center.plus(Vec2.of(-radius, radius)),
+					endPoint: center.plus(Vec2.of(-radius, 0)),
 				},
 				{
 					kind: PathCommandType.QuadraticBezierTo,
-					controlPoint: center.plus(Vec2.of(-width, -width)),
-					endPoint: center.plus(Vec2.of(0, -width)),
+					controlPoint: center.plus(Vec2.of(-radius, -radius)),
+					endPoint: center.plus(Vec2.of(0, -radius)),
 				},
 				{
 					kind: PathCommandType.QuadraticBezierTo,
-					controlPoint: center.plus(Vec2.of(width, -width)),
-					endPoint: center.plus(Vec2.of(width, 0)),
+					controlPoint: center.plus(Vec2.of(radius, -radius)),
+					endPoint: center.plus(Vec2.of(radius, 0)),
 				},
 			);
 			const connector: PathCommand = {

--- a/packages/js-draw/src/components/builders/autocorrect/makeShapeFitAutocorrect.ts
+++ b/packages/js-draw/src/components/builders/autocorrect/makeShapeFitAutocorrect.ts
@@ -4,6 +4,7 @@ import { StrokeDataPoint } from '../../../types';
 import AbstractComponent from '../../AbstractComponent';
 import { ComponentBuilder, ComponentBuilderFactory } from '../types';
 import AbstractRenderer from '../../../rendering/renderers/AbstractRenderer';
+import { StrokeStyle } from '../../../rendering/RenderingStyle';
 
 const makeShapeFitAutocorrect = (
 	sourceFactory: ComponentBuilderFactory,
@@ -36,6 +37,7 @@ const makeRectangleTemplate = (
 class ShapeFitBuilder implements ComponentBuilder {
 	private builder: ComponentBuilder;
 	private points: StrokeDataPoint[];
+	public readonly inkTrailStyle?: () => StrokeStyle;
 
 	public constructor(
 		private sourceFactory: ComponentBuilderFactory,
@@ -44,6 +46,10 @@ class ShapeFitBuilder implements ComponentBuilder {
 	) {
 		this.builder = sourceFactory(startPoint, viewport);
 		this.points = [startPoint];
+
+		if (this.builder.inkTrailStyle) {
+			this.inkTrailStyle = this.builder.inkTrailStyle.bind(this.builder);
+		}
 	}
 
 	public getBBox(): Rect2 {

--- a/packages/js-draw/src/components/builders/autocorrect/makeSnapToGridAutocorrect.ts
+++ b/packages/js-draw/src/components/builders/autocorrect/makeSnapToGridAutocorrect.ts
@@ -4,6 +4,7 @@ import { StrokeDataPoint } from '../../../types';
 import AbstractComponent from '../../AbstractComponent';
 import { ComponentBuilder, ComponentBuilderFactory } from '../types';
 import AbstractRenderer from '../../../rendering/renderers/AbstractRenderer';
+import { StrokeStyle } from '../../../rendering/RenderingStyle';
 
 const makeSnapToGridAutocorrect = (
 	sourceFactory: ComponentBuilderFactory,
@@ -18,6 +19,7 @@ export default makeSnapToGridAutocorrect;
 class SnapToGridAutocompleteBuilder implements ComponentBuilder {
 	private builder: ComponentBuilder;
 	private points: StrokeDataPoint[];
+	public inkTrailStyle?: () => StrokeStyle;
 
 	public constructor(
 		private sourceFactory: ComponentBuilderFactory,
@@ -26,6 +28,10 @@ class SnapToGridAutocompleteBuilder implements ComponentBuilder {
 	) {
 		this.builder = sourceFactory(startPoint, viewport);
 		this.points = [startPoint];
+
+		if (this.builder.inkTrailStyle) {
+			this.inkTrailStyle = this.builder.inkTrailStyle.bind(this.builder);
+		}
 	}
 
 	public getBBox(): Rect2 {

--- a/packages/js-draw/src/components/builders/types.ts
+++ b/packages/js-draw/src/components/builders/types.ts
@@ -3,11 +3,18 @@ import AbstractRenderer from '../../rendering/renderers/AbstractRenderer';
 import { StrokeDataPoint } from '../../types';
 import Viewport from '../../Viewport';
 import AbstractComponent from '../AbstractComponent';
+import { StrokeStyle } from '../../rendering/RenderingStyle';
 
 export interface ComponentBuilder {
 	getBBox(): Rect2;
 	build(): AbstractComponent;
 	preview(renderer: AbstractRenderer): void;
+
+	/**
+	 * (Optional) If provided, allows js-draw to efficiently render
+	 * an ink trail with the given style on some devices.
+	 */
+	inkTrailStyle?: () => StrokeStyle;
 
 	/**
 	 * Called when the pen is stationary (or the user otherwise

--- a/packages/js-draw/src/rendering/Display.ts
+++ b/packages/js-draw/src/rendering/Display.ts
@@ -6,6 +6,7 @@ import DummyRenderer from './renderers/DummyRenderer';
 import { Point2, Vec2, Color4 } from '@js-draw/math';
 import RenderingCache from './caching/RenderingCache';
 import TextOnlyRenderer from './renderers/TextOnlyRenderer';
+import AcceleratedInkingCanvasRenderer from './renderers/AcceleratedInkingCanvasRenderer';
 
 export enum RenderingMode {
 	DummyRenderer,
@@ -132,7 +133,7 @@ export default class Display {
 		const wetInkCtx = wetInkCanvas.getContext('2d')!;
 
 		this.dryInkRenderer = new CanvasRenderer(dryInkCtx, this.editor.viewport);
-		this.wetInkRenderer = new CanvasRenderer(wetInkCtx, this.editor.viewport);
+		this.wetInkRenderer = new AcceleratedInkingCanvasRenderer(wetInkCtx, this.editor.viewport);
 
 		dryInkCanvas.className = 'dryInkCanvas';
 		wetInkCanvas.className = 'wetInkCanvas';
@@ -250,6 +251,13 @@ export default class Display {
 	/** @internal */
 	public getDevicePixelRatio() {
 		return this.devicePixelRatio;
+	}
+
+	/** @internal -- used for internal performance improvements. */
+	public onPointerEvent(event: PointerEvent) {
+		if (this.wetInkRenderer instanceof AcceleratedInkingCanvasRenderer) {
+			this.wetInkRenderer.onEvent(event);
+		}
 	}
 
 	/**

--- a/packages/js-draw/src/rendering/renderers/AcceleratedInkingCanvasRenderer.ts
+++ b/packages/js-draw/src/rendering/renderers/AcceleratedInkingCanvasRenderer.ts
@@ -1,0 +1,67 @@
+import { StrokeStyle } from '../RenderingStyle';
+import { DraftInkPresenter } from './AbstractRenderer';
+import CanvasRenderer from './CanvasRenderer';
+import Viewport from '../../Viewport';
+
+interface NavigatorInkTrailPresenter {
+	updateInkTrailStartPoint(event: PointerEvent, style: { diameter: number; color: string }): void;
+}
+
+interface NavigatorInkApi {
+	requestPresenter(options: { presentationArea: Element }): Promise<NavigatorInkTrailPresenter>;
+}
+
+class CanvasInkPresenter implements DraftInkPresenter {
+	private enabled = new Map<number, boolean>();
+	private presenter: NavigatorInkTrailPresenter | null = null;
+	private style = { color: 'black', diameter: 2 };
+
+	public constructor(
+		canvas: HTMLCanvasElement,
+		private viewport: Viewport,
+	) {
+		if ('ink' in navigator && navigator.ink) {
+			const ink = navigator.ink as NavigatorInkApi;
+			ink.requestPresenter({ presentationArea: canvas }).then((presenter) => {
+				this.presenter = presenter;
+			});
+		}
+	}
+
+	public setEnabled(pointerId: number, enabled: boolean) {
+		this.enabled.set(pointerId, enabled);
+	}
+
+	public updateStyle(style: StrokeStyle) {
+		const colorString = style.color.toString();
+		// style.diameter must be a postive integer.
+		this.style = {
+			color: colorString,
+			diameter: Math.ceil(style.width / this.viewport.getSizeOfPixelOnCanvas()),
+		};
+	}
+
+	public onEvent(event: PointerEvent) {
+		if (this.presenter && this.enabled.get(event.pointerId) && event.isTrusted) {
+			this.presenter.updateInkTrailStartPoint(event, this.style);
+		}
+	}
+}
+
+/** A canvas that uses the web ink API for accelerated inking. */
+export default class AcceleratedInkingCanvasRenderer extends CanvasRenderer {
+	private inkPresenter: CanvasInkPresenter;
+
+	public constructor(ctx: CanvasRenderingContext2D, viewport: Viewport) {
+		super(ctx, viewport);
+		this.inkPresenter = new CanvasInkPresenter(ctx.canvas, viewport);
+	}
+
+	public override getDraftInkPresenter() {
+		return this.inkPresenter;
+	}
+
+	public onEvent(event: PointerEvent) {
+		this.inkPresenter.onEvent(event);
+	}
+}


### PR DESCRIPTION
# Summary

When available, uses the [Ink API](https://developer.mozilla.org/en-US/docs/Web/API/Ink_API) to accelerate inking.

Resolves #115.

# Testing <!-- (if applicable) -->

Manual testing (Chromium):
1. Open the demo page.
2. Switch to the highlighter tool.
3. Set the tool radius to a large number.
4. Draw something.
5. Verify that a rounded preview is overlayed with the last part of the highlight (indicating that the web ink API is in use).

# Possible tasks

- [ ] When snap-to-grid (<kbd>ctrl</kbd>) or plane-lock (<kbd>shift</kbd>) is enabled, the ink preview is visible: <img width="240" alt="screenshot, red circle near mouse cursor, below a line segment of the same color" src="https://github.com/user-attachments/assets/4e47acf4-bce3-4b30-961d-6a19b47f8ac6"/>
- [ ] When drawing with the highlighter tool, the ink trail is rounded (not flat): <img width="240" alt="screenshot, red circle near mouse cursor, after a flat-edged wobbly line segment of the same color. The red circle partially overlaps with the stroke." src="https://github.com/user-attachments/assets/14268f65-d2bd-4a23-972a-0aea1071adf8"/>
    - Disable the web ink API for highlighters with large stroke width?

    - To make this less noticeable


